### PR TITLE
Bonemeal list always filled

### DIFF
--- a/asparagus_default.lua
+++ b/asparagus_default.lua
@@ -46,11 +46,8 @@ minetest.register_node("cucina_vegana:wild_" .. pname, {
 	},
 })
 
-if(cucina_vegana.plant_settings.bonemeal) then
-    table.insert(cucina_vegana.plant_settings.bonemeal_list,
-								{"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:seed_" .. pname})
-
-end -- if(cucina_vegana.plant_settings.bonemeal
+table.insert(cucina_vegana.plant_settings.bonemeal_list,
+    {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:seed_" .. pname})
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then

--- a/asparagus_redo.lua
+++ b/asparagus_redo.lua
@@ -127,11 +127,8 @@ end
 		},
 	})
 
-if(cucina_vegana.plant_settings.bonemeal) then
-    table.insert(cucina_vegana.plant_settings.bonemeal_list,
-                 {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:" .. pname .. "_seed"})
-
-end -- if(cucina_vegana.plant_settings.bonemeal
+table.insert(cucina_vegana.plant_settings.bonemeal_list,
+    {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:" .. pname .. "_seed"})
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then

--- a/chives_default.lua
+++ b/chives_default.lua
@@ -46,11 +46,8 @@ minetest.register_node("cucina_vegana:wild_" .. pname, {
 	},
 })
 
-if(cucina_vegana.plant_settings.bonemeal) then
-    table.insert(cucina_vegana.plant_settings.bonemeal_list,
-                 {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:seed_" .. pname})
-
-end -- if(cucina_vegana.plant_settings.bonemeal
+table.insert(cucina_vegana.plant_settings.bonemeal_list,
+             {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:seed_" .. pname})
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then

--- a/chives_redo.lua
+++ b/chives_redo.lua
@@ -118,11 +118,8 @@ minetest.register_node("cucina_vegana:wild_" .. pname .. "", {
 	},
 })
 
-if(cucina_vegana.plant_settings.bonemeal) then
-    table.insert(cucina_vegana.plant_settings.bonemeal_list,
-                 {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:" .. pname .. "_seed"})
-
-end -- if(cucina_vegana.plant_settings.bonemeal
+table.insert(cucina_vegana.plant_settings.bonemeal_list,
+             {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:" .. pname .. "_seed"})
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then

--- a/flax_default.lua
+++ b/flax_default.lua
@@ -48,11 +48,8 @@ minetest.register_node("cucina_vegana:wild_" .. pname, {
 
 cucina_vegana.add_group("cucina_vegana:seed_" .. pname, {seed_flax = 1})
 
-if(cucina_vegana.plant_settings.bonemeal) then
-    table.insert(cucina_vegana.plant_settings.bonemeal_list,
-                 {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:seed_" .. pname})
-
-end -- if(cucina_vegana.plant_settings.bonemeal
+table.insert(cucina_vegana.plant_settings.bonemeal_list,
+             {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:seed_" .. pname})
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then

--- a/flax_redo.lua
+++ b/flax_redo.lua
@@ -121,11 +121,8 @@ minetest.register_node("cucina_vegana:wild_" .. pname .. "", {
 
 cucina_vegana.add_group("cucina_vegana:" .. pname .. "_seed", {seed_flax = 1})
 
-if(cucina_vegana.plant_settings.bonemeal) then
-    table.insert(cucina_vegana.plant_settings.bonemeal_list,
-								 {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:" .. pname .. "_seed"})
-
-end -- if(cucina_vegana.plant_settings.bonemeal
+table.insert(cucina_vegana.plant_settings.bonemeal_list,
+				 {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:" .. pname .. "_seed"})
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then

--- a/kohlrabi_default.lua
+++ b/kohlrabi_default.lua
@@ -50,11 +50,8 @@ minetest.register_alias("kohlrabi:kohlrabi", "cucina_vegana:" .. pname)
 minetest.register_alias("kohlrabi:seed", "cucina_vegana:" .. pname .. "_seed")
 minetest.register_alias("kohlrabi:wild_kohlrabi", "cucina_vegana:wild_" .. pname)
 
-if(cucina_vegana.plant_settings.bonemeal) then
-    table.insert(cucina_vegana.plant_settings.bonemeal_list,
-                 {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:seed_" .. pname})
-
-end -- if(cucina_vegana.plant_settings.bonemeal
+table.insert(cucina_vegana.plant_settings.bonemeal_list,
+             {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:seed_" .. pname})
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then

--- a/kohlrabi_redo.lua
+++ b/kohlrabi_redo.lua
@@ -141,11 +141,8 @@ minetest.register_alias("kohlrabi:kohlrabi", "cucina_vegana:" .. pname .. "")
 minetest.register_alias("kohlrabi:seed", "cucina_vegana:" .. pname .. "_seed")
 minetest.register_alias("kohlrabi:wild_kohlrabi", "cucina_vegana:wild_" .. pname .. "")
 
-if(cucina_vegana.plant_settings.bonemeal) then
-    table.insert(cucina_vegana.plant_settings.bonemeal_list,
-                 {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:" .. pname .. "_seed"})
-
-end -- if(cucina_vegana.plant_settings.bonemeal
+table.insert(cucina_vegana.plant_settings.bonemeal_list,
+             {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:" .. pname .. "_seed"})
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then

--- a/lettuce_default.lua
+++ b/lettuce_default.lua
@@ -53,11 +53,8 @@ minetest.register_alias("lettuce:lettuce", "cucina_vegana:" .. pname)
 minetest.register_alias("lettuce:seed", "cucina_vegana:" .. pname .. "_seed")
 minetest.register_alias("lettuce:wild_lettuce", "cucina_vegana:wild_" .. pname)
 
-if(cucina_vegana.plant_settings.bonemeal) then
-    table.insert(cucina_vegana.plant_settings.bonemeal_list,
-                 {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:seed_" .. pname})
-
-end -- if(cucina_vegana.plant_settings.bonemeal
+table.insert(cucina_vegana.plant_settings.bonemeal_list,
+             {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:seed_" .. pname})
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then

--- a/lettuce_redo.lua
+++ b/lettuce_redo.lua
@@ -131,11 +131,8 @@ minetest.register_alias("lettuce:lettuce", "cucina_vegana:" .. pname .. "")
 minetest.register_alias("lettuce:seed", "cucina_vegana:" .. pname .. "_seed")
 minetest.register_alias("lettuce:wild_lettuce", "cucina_vegana:wild_" .. pname .. "")
 
-if(cucina_vegana.plant_settings.bonemeal) then
-    table.insert(cucina_vegana.plant_settings.bonemeal_list,
-                 {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:" .. pname .. "_seed"})
-
-end -- if(cucina_vegana.plant_settings.bonemeal
+table.insert(cucina_vegana.plant_settings.bonemeal_list,
+             {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:" .. pname .. "_seed"})
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then

--- a/parsley_default.lua
+++ b/parsley_default.lua
@@ -50,11 +50,8 @@ minetest.register_alias("parsley:parsley", "cucina_vegana:" .. pname)
 minetest.register_alias("parsley:seed", "cucina_vegana:" .. pname .. "_seed")
 minetest.register_alias("parsley:wild_parsley", "cucina_vegana:wild_" .. pname)
 
-if(cucina_vegana.plant_settings.bonemeal) then
-    table.insert(cucina_vegana.plant_settings.bonemeal_list,
-                 {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:seed_" .. pname})
-
-end -- if(cucina_vegana.plant_settings.bonemeal
+table.insert(cucina_vegana.plant_settings.bonemeal_list,
+             {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:seed_" .. pname})
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then

--- a/parsley_redo.lua
+++ b/parsley_redo.lua
@@ -131,11 +131,8 @@ minetest.register_alias("parsley:parsley", "cucina_vegana:" .. pname .. "")
 minetest.register_alias("parsley:seed", "cucina_vegana:" .. pname .. "_seed")
 minetest.register_alias("parsley:wild_parsley", "cucina_vegana:wild_" .. pname .. "")
 
-if(cucina_vegana.plant_settings.bonemeal) then
-    table.insert(cucina_vegana.plant_settings.bonemeal_list,
-                 {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:" .. pname .. "_seed"})
-
-end -- if(cucina_vegana.plant_settings.bonemeal
+table.insert(cucina_vegana.plant_settings.bonemeal_list,
+             {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:" .. pname .. "_seed"})
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then

--- a/peanut_default.lua
+++ b/peanut_default.lua
@@ -47,11 +47,8 @@ minetest.register_node("cucina_vegana:wild_" .. pname, {
 
 cucina_vegana.add_group("cucina_vegana:seed_" .. pname, {seed_peanut = 1})
 
-if(cucina_vegana.plant_settings.bonemeal) then
-    table.insert(cucina_vegana.plant_settings.bonemeal_list,
-                 {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:seed_" .. pname})
-
-end -- if(cucina_vegana.plant_settings.bonemeal
+table.insert(cucina_vegana.plant_settings.bonemeal_list,
+             {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:seed_" .. pname})
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then

--- a/peanut_redo.lua
+++ b/peanut_redo.lua
@@ -122,11 +122,8 @@ minetest.register_node("cucina_vegana:wild_" .. pname .. "", {
 
 cucina_vegana.add_group("cucina_vegana:" .. pname .. "_seed", {seed_peanut = 1})
 
-if(cucina_vegana.plant_settings.bonemeal) then
-    table.insert(cucina_vegana.plant_settings.bonemeal_list,
-                 {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:" .. pname .. "_seed"})
-
-end -- if(cucina_vegana.plant_settings.bonemeal
+table.insert(cucina_vegana.plant_settings.bonemeal_list,
+             {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:" .. pname .. "_seed"})
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then

--- a/rice_default.lua
+++ b/rice_default.lua
@@ -46,11 +46,8 @@ minetest.register_node("cucina_vegana:wild_" .. pname, {
 	},
 })
 
-if(cucina_vegana.plant_settings.bonemeal) then
-    table.insert(cucina_vegana.plant_settings.bonemeal_list,
-                 {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:seed_" .. pname})
-
-end -- if(cucina_vegana.plant_settings.bonemeal
+table.insert(cucina_vegana.plant_settings.bonemeal_list,
+             {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:seed_" .. pname})
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then

--- a/rice_redo.lua
+++ b/rice_redo.lua
@@ -127,11 +127,8 @@ end
 		},
 	})
 
-if(cucina_vegana.plant_settings.bonemeal) then
-    table.insert(cucina_vegana.plant_settings.bonemeal_list,
-                 {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:" .. pname .. "_seed"})
-
-end -- if(cucina_vegana.plant_settings.bonemeal
+table.insert(cucina_vegana.plant_settings.bonemeal_list,
+             {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:" .. pname .. "_seed"})
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then

--- a/rosemary_default.lua
+++ b/rosemary_default.lua
@@ -46,11 +46,8 @@ minetest.register_node("cucina_vegana:wild_" .. pname, {
 	},
 })
 
-if(cucina_vegana.plant_settings.bonemeal) then
-    table.insert(cucina_vegana.plant_settings.bonemeal_list,
-                 {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:seed_" .. pname})
-
-end -- if(cucina_vegana.plant_settings.bonemeal
+table.insert(cucina_vegana.plant_settings.bonemeal_list,
+             {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:seed_" .. pname})
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then

--- a/rosemary_redo.lua
+++ b/rosemary_redo.lua
@@ -128,11 +128,8 @@ minetest.register_node("cucina_vegana:wild_" .. pname, {
 	},
 })
 
-if(cucina_vegana.plant_settings.bonemeal) then
-    table.insert(cucina_vegana.plant_settings.bonemeal_list,
-                 {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:" .. pname .. "_seed"})
-
-end -- if(cucina_vegana.plant_settings.bonemeal
+table.insert(cucina_vegana.plant_settings.bonemeal_list,
+             {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:" .. pname .. "_seed"})
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then

--- a/soy_default.lua
+++ b/soy_default.lua
@@ -52,11 +52,8 @@ minetest.register_alias("soy:wild_".. pname, "cucina_vegana:wild_".. pname)
 minetest.register_alias("soy:".. pname, "cucina_vegana:".. pname)
 minetest.register_alias("soy:seed_".. pname, "cucina_vegana:seed_".. pname)
 
-if(cucina_vegana.plant_settings.bonemeal) then
-    table.insert(cucina_vegana.plant_settings.bonemeal_list,
-                 {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:seed_" .. pname})
-
-end -- if(cucina_vegana.plant_settings.bonemeal
+table.insert(cucina_vegana.plant_settings.bonemeal_list,
+             {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:seed_" .. pname})
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then

--- a/soy_redo.lua
+++ b/soy_redo.lua
@@ -161,11 +161,8 @@ minetest.register_alias("soy:wild_soy", "cucina_vegana:wild_" .. pname)
 minetest.register_alias("soy:soy", "cucina_vegana:" .. pname)
 minetest.register_alias("soy:seed_soy", "cucina_vegana:seed_" .. pname)
 
-if(cucina_vegana.plant_settings.bonemeal) then
-    table.insert(cucina_vegana.plant_settings.bonemeal_list,
-                 {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:" .. pname .. "_seed"})
-
-end -- if(cucina_vegana.plant_settings.bonemeal
+table.insert(cucina_vegana.plant_settings.bonemeal_list,
+             {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:" .. pname .. "_seed"})
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then

--- a/sunflower_default.lua
+++ b/sunflower_default.lua
@@ -55,11 +55,8 @@ else
 
 end
 
-if(cucina_vegana.plant_settings.bonemeal) then
-    table.insert(cucina_vegana.plant_settings.bonemeal_list,
-                 {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:seed_" .. pname})
-
-end -- if(cucina_vegana.plant_settings.bonemeal
+table.insert(cucina_vegana.plant_settings.bonemeal_list,
+             {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:seed_" .. pname})
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then

--- a/sunflower_redo.lua
+++ b/sunflower_redo.lua
@@ -123,11 +123,8 @@ else
 
 end
 
-if(cucina_vegana.plant_settings.bonemeal) then
-    table.insert(cucina_vegana.plant_settings.bonemeal_list,
-                 {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:" .. pname .. "_seed"})
-
-end -- if(cucina_vegana.plant_settings.bonemeal
+table.insert(cucina_vegana.plant_settings.bonemeal_list,
+             {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:" .. pname .. "_seed"})
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then


### PR DESCRIPTION
Following [issue](https://github.com/acmgit/cucina_vegana/issues/11) I open this pull request.
The only change is bonemeal_list is always exported, in my maidroid version I iterate over this list, to inform farmers of selectable mature plants.

`for _, val in ipairs(cucina_vegana.plant_settings.bonemeal_list) do`
   `table.insert(target_plants, val[1] .. val[2])`
`end`

P.S.: I forked immediately and the PR was ready as it is quite straightforward, but forgot to 'create pull request'