### PR TITLE
Move sunflower item overrides into block where they are defined

### DIFF
--- a/sunflower_default.lua
+++ b/sunflower_default.lua
@@ -55,10 +55,10 @@ else
 		},
 	})
 
-end
+	minetest.override_item("cucina_vegana:" .. pname .. "_4", {visual_scale = 1.3})
+	minetest.override_item("cucina_vegana:" .. pname .. "_5", {visual_scale = 1.5})
 
-minetest.override_item("cucina_vegana:" .. pname .. "_4", {visual_scale = 1.3})
-minetest.override_item("cucina_vegana:" .. pname .. "_5", {visual_scale = 1.5})
+end
 
 if(cucina_vegana.plant_settings.bonemeal) then
     table.insert(cucina_vegana.plant_settings.bonemeal_list,


### PR DESCRIPTION
While doing compatibility testing I noticed a crash when running a mod that adds ``flowers:sunflower`` - like the plantlife modpack - in addition to Cucina Vegana. 

Just moving the overrides into the block above where the nodes to override are defined fixes it.