### PR TITLE
Cleanup [Part 1]: Replace `minetest.` with `core.` and rename to Luanti

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cucina Vegana
 
 
-This Mod adds some new Plants for vegan cooking in Minetest.
+This Mod adds some new Plants for vegan cooking in Luanti.
 It supports farming and farming_redo from TenPlus.
 
 ## Soy

--- a/aliases.lua
+++ b/aliases.lua
@@ -1,2 +1,2 @@
 
-minetest.register_alias("cucina_vegana:corn_cob", "cucina_vegana:corn")
+core.register_alias("cucina_vegana:corn_cob", "cucina_vegana:corn")

--- a/asparagus.lua
+++ b/asparagus.lua
@@ -23,7 +23,7 @@ farming.register_plant("cucina_vegana:" .. pname, {
 })
 
 -- Register for Mapgen
-minetest.register_node("cucina_vegana:wild_" .. pname, {
+core.register_node("cucina_vegana:wild_" .. pname, {
 	description = S("Wild") .. " " .. dname,
 	paramtype = "light",
 	walkable = false,
@@ -66,7 +66,7 @@ if(cucina_vegana.signs_bot) then
 
 end
 
-minetest.register_decoration({
+core.register_decoration({
 	deco_type = "simple",
 	place_on = {"default:dirt_with_grass", "default:dirt_with_rainforest_litter"},
 	spawn_by = {"default:tree", "default:aspen_tree", "default:jungletree"},

--- a/banana.lua
+++ b/banana.lua
@@ -23,12 +23,12 @@ farming.register_plant("cucina_vegana:" .. pname, {
 	visual_scale = 1,
 })
 
-minetest.override_item("cucina_vegana:" .. pname .. "_6", {visual_scale = 1.3})
-minetest.override_item("cucina_vegana:" .. pname .. "_7", {visual_scale = 1.6})
-minetest.override_item("cucina_vegana:" .. pname .. "_8", {visual_scale = 1.9})
+core.override_item("cucina_vegana:" .. pname .. "_6", {visual_scale = 1.3})
+core.override_item("cucina_vegana:" .. pname .. "_7", {visual_scale = 1.6})
+core.override_item("cucina_vegana:" .. pname .. "_8", {visual_scale = 1.9})
 
 -- Register for Mapgen
-minetest.register_node("cucina_vegana:wild_" .. pname, {
+core.register_node("cucina_vegana:wild_" .. pname, {
 	description = S("Wild") .. " " .. dname,
 	paramtype = "light",
 	walkable = false,
@@ -73,7 +73,7 @@ if(cucina_vegana.signs_bot) then
 end
 
 -- mapgen
-minetest.register_decoration({
+core.register_decoration({
 	deco_type = "simple",
 	place_on = {"default:dirt_with_rainforest_litter", "default:dirt"},
 	spawn_by = {"default:jungletree"},

--- a/carrot.lua
+++ b/carrot.lua
@@ -23,7 +23,7 @@ farming.register_plant("cucina_vegana:" .. pname, {
 })
 
 -- Register for Mapgen
-minetest.register_node("cucina_vegana:wild_" .. pname, {
+core.register_node("cucina_vegana:wild_" .. pname, {
 	description = S("Wild") .. " " .. dname,
 	paramtype = "light",
 	walkable = false,
@@ -68,7 +68,7 @@ if(cucina_vegana.signs_bot) then
 
 end
 
-minetest.register_decoration({
+core.register_decoration({
 	deco_type = "simple",
 	place_on = {"default:dirt", "default:dirt_with_grass", "default:dry_dirt_with_dry_grass"},
 	sidelen = 16,

--- a/chili.lua
+++ b/chili.lua
@@ -23,7 +23,7 @@ farming.register_plant("cucina_vegana:" .. pname, {
 })
 
 -- Register for Mapgen
-minetest.register_node("cucina_vegana:wild_" .. pname, {
+core.register_node("cucina_vegana:wild_" .. pname, {
 	description = S("Wild") .. " " .. dname,
 	paramtype = "light",
 	walkable = false,
@@ -68,7 +68,7 @@ if(cucina_vegana.signs_bot) then
 
 end
 
-minetest.register_decoration({
+core.register_decoration({
 	deco_type = "simple",
 	place_on = {"default:dirt_with_rainforest_litter", "default:dry_dirt_with_dry_grass"},
 	sidelen = 16,

--- a/chives.lua
+++ b/chives.lua
@@ -23,7 +23,7 @@ farming.register_plant("cucina_vegana:" .. pname, {
 })
 
 -- Register for Mapgen
-minetest.register_node("cucina_vegana:wild_" .. pname, {
+core.register_node("cucina_vegana:wild_" .. pname, {
 	description = S("Wild") .. " " .. dname,
 	paramtype = "light",
 	walkable = false,
@@ -67,7 +67,7 @@ if(cucina_vegana.signs_bot) then
 
 end
 
-minetest.register_decoration({
+core.register_decoration({
 	deco_type = "simple",
 	place_on = {"default:dirt_with_grass"},
 	sidelen = 16,

--- a/coffee.lua
+++ b/coffee.lua
@@ -1,5 +1,5 @@
 
-minetest.register_decoration({
+core.register_decoration({
 	deco_type = "simple",
 	place_on = {"default:dirt_with_rainforest_litter", "default:dirt",},
 	sidelen = 16,

--- a/coffee_def.lua
+++ b/coffee_def.lua
@@ -5,7 +5,6 @@
 ]]--
 
 local cv = cucina_vegana
-local mt = minetest
 
 -- Load support for intllib.
 local S = cv.get_translator
@@ -19,7 +18,7 @@ local maxlight = cv.shrub_settings.coffee_light
 local percent = 3
 
 -- Register for Mapgen
-mt.register_node("cucina_vegana:wild_" .. pname, {
+core.register_node("cucina_vegana:wild_" .. pname, {
 	description = S("Wild" ) .. " " .. dname .. " " .. S("Stem"),
 	paramtype = "light",
 	walkable = true,
@@ -45,7 +44,7 @@ mt.register_node("cucina_vegana:wild_" .. pname, {
 	},
 })
 
-mt.register_node("cucina_vegana:" .. pname .. "_leaves", {
+core.register_node("cucina_vegana:" .. pname .. "_leaves", {
 	description = dname .. " " .. S("Leaves"),
 	paramtype = "light",
 	walkable = true,
@@ -78,15 +77,15 @@ mt.register_node("cucina_vegana:" .. pname .. "_leaves", {
 						end,
 })
 
-mt.register_craftitem("cucina_vegana:" .. pname .. "_beans_raw", {
+core.register_craftitem("cucina_vegana:" .. pname .. "_beans_raw", {
 	description = S("Coffee Beans raw"),
 	inventory_image = "cucina_vegana_" .. pname .. "_beans_raw.png",
 	groups = {food = 1, food_coffee = 1},
-    on_use = mt.item_eat(3)
+    on_use = core.item_eat(3)
 
 })
 
-mt.register_node("cucina_vegana:" .. pname .. "_sapling", {
+core.register_node("cucina_vegana:" .. pname .. "_sapling", {
 	description = dname .. " " .. S("Sapling"),
 	paramtype = "light",
 	walkable = true,
@@ -112,7 +111,7 @@ mt.register_node("cucina_vegana:" .. pname .. "_sapling", {
 cv.lib.register_bottom_abm("cucina_vegana:" .. pname .. "_sapling", "cucina_vegana:" .. pname .. "_bottom_1", duration, maxlight)
 
 for step = 1, bottom_steps do
-	mt.register_node("cucina_vegana:" .. pname .. "_bottom_" .. step, {
+	core.register_node("cucina_vegana:" .. pname .. "_bottom_" .. step, {
 		description = dname,
 		paramtype = "light",
 		walkable = true,
@@ -144,7 +143,7 @@ for step = 1, bottom_steps do
 
 end -- for step
 
-mt.register_abm({
+core.register_abm({
     nodenames = {"cucina_vegana:" .. pname .. "_bottom_" .. bottom_steps},
     interval = duration,
     chance = percent,
@@ -153,7 +152,7 @@ mt.register_abm({
                 local nodepos = { x = pos.x, y = pos.y+1, z = pos.z}
 	                if(cv.lib.check_light(nodepos, maxlight)) then
                         if(cv.lib.check_air(nodepos)) then
-                            mt.set_node(nodepos, {name = "cucina_vegana:" .. pname .. "_top_1"})
+                            core.set_node(nodepos, {name = "cucina_vegana:" .. pname .. "_top_1"})
 
                         end -- if(check_air)
 
@@ -161,10 +160,10 @@ mt.register_abm({
 
             end, -- function(
 
-}) -- minetest.register_abm({
+}) -- core.register_abm({
 
 for step = 1, top_steps do
-	mt.register_node("cucina_vegana:" .. pname .. "_top_" .. step, {
+	core.register_node("cucina_vegana:" .. pname .. "_top_" .. step, {
 		description = dname,
 		paramtype = "light",
 		walkable = false,

--- a/corn.lua
+++ b/corn.lua
@@ -22,12 +22,12 @@ farming.register_plant("cucina_vegana:" .. pname, {
 	groups = {flammable = 4, attached_node = 1},
 })
 
-minetest.override_item("cucina_vegana:" .. pname .. "_5", {visual_scale = 1.3})
-minetest.override_item("cucina_vegana:" .. pname .. "_6", {visual_scale = 1.6})
-minetest.override_item("cucina_vegana:" .. pname .. "_7", {visual_scale = 1.9})
+core.override_item("cucina_vegana:" .. pname .. "_5", {visual_scale = 1.3})
+core.override_item("cucina_vegana:" .. pname .. "_6", {visual_scale = 1.6})
+core.override_item("cucina_vegana:" .. pname .. "_7", {visual_scale = 1.9})
 
 -- Register for Mapgen
-minetest.register_node("cucina_vegana:wild_" .. pname, {
+core.register_node("cucina_vegana:wild_" .. pname, {
 	description = S("Wild") .. " " .. dname,
 	paramtype = "light",
 	walkable = false,
@@ -71,7 +71,7 @@ if(cucina_vegana.signs_bot) then
 
 end
 
-minetest.register_decoration({
+core.register_decoration({
 	deco_type = "simple",
 	place_on = {"default:dry_dirt_with_dry_grass", "default:dirt", "default:dirt_with_grass", "default:dirt_dry"},
 	sidelen = 16,

--- a/cucumber.lua
+++ b/cucumber.lua
@@ -23,7 +23,7 @@ farming.register_plant("cucina_vegana:" .. pname, {
 })
 
 -- Register for Mapgen
-minetest.register_node("cucina_vegana:wild_" .. pname, {
+core.register_node("cucina_vegana:wild_" .. pname, {
 	description = S("Wild") .. " " .. dname,
 	paramtype = "light",
 	walkable = false,
@@ -66,7 +66,7 @@ if(cucina_vegana.signs_bot) then
 
 end
 
-minetest.register_decoration({
+core.register_decoration({
 	deco_type = "simple",
 	place_on = {"default:dirt_with_grass", "default:dirt_with_rainforest_litter"},
 	spawn_by = {"default:tree", "default:aspen_tree", "default:jungletree"},

--- a/flax.lua
+++ b/flax.lua
@@ -23,7 +23,7 @@ farming.register_plant("cucina_vegana:" .. pname, {
 })
 
 -- Register for Mapgen
-minetest.register_node("cucina_vegana:wild_" .. pname, {
+core.register_node("cucina_vegana:wild_" .. pname, {
 	description = S("Wild") .. " " .. dname,
 	paramtype = "light",
 	walkable = false,
@@ -68,7 +68,7 @@ if(cucina_vegana.signs_bot) then
 
 end
 
-minetest.register_decoration({
+core.register_decoration({
 	deco_type = "simple",
 	place_on = {"default:dirt_with_grass", "default:dry_dirt_with_dry_grass"},
 	sidelen = 16,

--- a/fuels.lua
+++ b/fuels.lua
@@ -2,120 +2,120 @@
 --   *****                 Fuels                        *****
 --   *******************************************
 
-minetest.register_craft({
+core.register_craft({
 	type = "fuel",
 	recipe = "cucina_vegana:sunflower_seeds_oil",
 	burntime = 30,
 	replacements = {{ "cucina_vegana:sunflower_seeds_oil", "vessels:glass_bottle"}}
 })
 
-minetest.register_craft({
+core.register_craft({
 	type = "fuel",
 	recipe = "cucina_vegana:flax_seed_oil",
 	burntime = 30,
 	replacements = {{ "cucina_vegana:flax_seed_oil", "vessels:glass_bottle"}}
 })
 
-minetest.register_craft({
+core.register_craft({
 	type = "fuel",
 	recipe = "cucina_vegana:peanut_oil",
 	burntime = 35,
 	replacements = {{ "cucina_vegana:peanut_oil", "vessels:glass_bottle"}}
 })
 
-minetest.register_craft({
+core.register_craft({
 	type = "fuel",
 	recipe = "cucina_vegana:corn_oil",
 	burntime = 35,
 	replacements = {{ "cucina_vegana:corn_oil", "vessels:glass_bottle"}}
 })
 
-minetest.register_craft({
+core.register_craft({
 	type = "fuel",
 	recipe = "cucina_vegana:flax_seed",
 	burntime = 10
 })
 
-minetest.register_craft({
+core.register_craft({
 	type = "fuel",
 	recipe = "cucina_vegana:flax_roasted",
 	burntime = 7
 })
 
-minetest.register_craft({
+core.register_craft({
 	type = "fuel",
 	recipe = "cucina_vegana:sunflower_seeds",
 	burntime = 2
 })
 
-minetest.register_craft({
+core.register_craft({
 	type = "fuel",
 	recipe = "cucina_vegana:peanut",
 	burntime = 5
 })
 
-minetest.register_craft({
+core.register_craft({
 	type = "fuel",
 	recipe = "cucina_vegana:sunflower_seeds_roasted",
 	burntime = 2
 })
 
-minetest.register_craft({
+core.register_craft({
 	type = "fuel",
 	recipe = "cucina_vegana:soy",
 	burntime = 1,
 })
 
-minetest.register_craft({
+core.register_craft({
 	type = "fuel",
 	recipe = "cucina_vegana:parsley",
 	burntime = 1,
 })
 
-minetest.register_craft({
+core.register_craft({
 	type = "fuel",
 	recipe = "cucina_vegana:lettuce",
 	burntime = 2,
 })
 
-minetest.register_craft({
+core.register_craft({
 	type = "fuel",
 	recipe = "cucina_vegana:lettuce_oil",
 	burntime = 30,
 	replacements = {{ "cucina_vegana:lettuce_oil", "vessels:glass_bottle"}}
 })
 
-minetest.register_craft({
+core.register_craft({
 	type = "fuel",
 	recipe = "cucina_vegana:kohlrabi",
 	burntime = 3,
 })
 
-minetest.register_craft({
+core.register_craft({
 	type = "fuel",
 	recipe = "cucina_vegana:kohlrabi_roasted",
 	burntime = 4
 })
 
-minetest.register_craft({
+core.register_craft({
 	type = "fuel",
 	recipe = "cucina_vegana:chives",
 	burntime = 1,
 })
 
-minetest.register_craft({
+core.register_craft({
 	type = "fuel",
 	recipe = "cucina_vegana:asparagus",
 	burntime = 3,
 })
 
-minetest.register_craft({
+core.register_craft({
 	type = "fuel",
 	recipe = "cucina_vegana:rice",
 	burntime = 5,
 })
 
-minetest.register_craft({
+core.register_craft({
 	type = "fuel",
 	recipe = "cucina_vegana:molasses",
 	burntime = 10,

--- a/garlic.lua
+++ b/garlic.lua
@@ -23,7 +23,7 @@ farming.register_plant("cucina_vegana:" .. pname, {
 })
 
 -- Register for Mapgen
-minetest.register_node("cucina_vegana:wild_" .. pname, {
+core.register_node("cucina_vegana:wild_" .. pname, {
 	description = S("Wild") .. " " .. dname,
 	paramtype = "light",
 	walkable = false,
@@ -68,7 +68,7 @@ if(cucina_vegana.signs_bot) then
 
 end
 
-minetest.register_decoration({
+core.register_decoration({
 	deco_type = "simple",
 	place_on = {"default:dirt_with_grass", "default:dirt"},
 	sidelen = 16,

--- a/init.lua
+++ b/init.lua
@@ -2,7 +2,7 @@
 	**********************************************
 	***             Cucina Vegana              ***
     ***                                        ***
-    ***  Cucina Vegana is a Mod for Minetest   ***
+    ***  Cucina Vegana is a Mod for Luanti     ***
     ***  and supports farming or farming_redo  ***
     ***  by TenPlus.                           ***
     ***                                        ***
@@ -19,29 +19,29 @@ cucina_vegana.settings = {}
 cucina_vegana.plant_settings = {}
 cucina_vegana.shrub_settings = {}
 cucina_vegana.plant_settings.bonemeal_list = {}
-cucina_vegana.farming_ng = minetest.get_modpath("farming_nextgen")
-cucina_vegana.signs_bot = minetest.get_modpath("signs_bot")
+cucina_vegana.farming_ng = core.get_modpath("farming_nextgen")
+cucina_vegana.signs_bot = core.get_modpath("signs_bot")
 cucina_vegana.register_signs_bot = nil
 cucina_vegana.plant_settings.germ_launch = 0
-cucina_vegana.modname = minetest.get_current_modname()
+cucina_vegana.modname = core.get_current_modname()
 
-local modpath = minetest.get_modpath(minetest.get_current_modname())
+local modpath = core.get_modpath(core.get_current_modname())
 local modname = cucina_vegana.modname
 
 local S
 
-if(minetest.get_modpath("intllib")) then
+if(core.get_modpath("intllib")) then
     S = dofile(modpath .."/intllib.lua")
-    minetest.log("info","[MOD] " .. modname .. ": translating in intllib-mode.")
+    core.log("info","[MOD] " .. modname .. ": translating in intllib-mode.")
 
-elseif minetest.get_translator ~= nil then
-    S = minetest.get_translator("cucina_vegana")
-    minetest.log("info", "[MOD] " .. modname .. ": translating in minetest-mode.")
+elseif core.get_translator ~= nil then
+    S = core.get_translator("cucina_vegana")
+    core.log("info", "[MOD] " .. modname .. ": translating in minetest-mode.")
 
 else
     S = function ( s ) return s end
 
-end -- if(minetest.get_modpath(
+end -- if(core.get_modpath(
 
 cucina_vegana.get_translator = S
 
@@ -56,18 +56,18 @@ end
 -- looking if farming_redo is really activ? ... \/('')\/
 if(farming.mod ~= nil and farming.mod == "redo") then
 	cucina_vegana.farming_default = false
-    minetest.log("info", "[MOD] " .. modname .. ": farming_redo mode activated.")
+    core.log("info", "[MOD] " .. modname .. ": farming_redo mode activated.")
 
 else
-    minetest.log("info", "[MOD] " .. modname .. ": default farming mode activated.")
+    core.log("info", "[MOD] " .. modname .. ": default farming mode activated.")
 
 end -- if(farming.mod
 
 cucina_vegana.plant_settings.bonemeal = false         -- Support for bonemeal disabled
-if(minetest.get_modpath("bonemeal")) or minetest.get_modpath("maidroid") then
+if(core.get_modpath("bonemeal")) or core.get_modpath("maidroid") then
     cucina_vegana.plant_settings.bonemeal = true
 
-end -- if(minetest.get_modpath("bonemeal"
+end -- if(core.get_modpath("bonemeal"
 
 local plants = {
 
@@ -102,11 +102,11 @@ for pname, value in pairs(plants) do
         -- Load all flowers in default-mode
 			dofile(modpath .. "/" .. pname .. ".lua")
 			dofile(modpath .. "/".. pname .. ".lua")
-			minetest.register_alias(n_redo, n_default)
+			core.register_alias(n_redo, n_default)
 
 	end -- if(value)
 
-    minetest.log("info", "[MOD] " .. modname .. " Module: " .. pname .. " loaded.")
+    core.log("info", "[MOD] " .. modname .. " Module: " .. pname .. " loaded.")
 
 end -- for
 
@@ -119,7 +119,7 @@ for sname, value in pairs(shrubs) do
 	if(value) then
 		dofile(modpath .. "/" .. sname .. "_def.lua")
 		dofile(modpath .. "/" .. sname .. ".lua")
-	    minetest.log("info", "[MOD] " .. modname .. " Module: " .. sname .. " loaded.")
+	    core.log("info", "[MOD] " .. modname .. " Module: " .. sname .. " loaded.")
 	end -- if(value)
 
 
@@ -137,9 +137,9 @@ dofile(modpath .. "/recipes_5xx.lua") -- New recipes with MT 5.0
 dofile(modpath .. "/register_mods.lua")
 dofile(modpath .. "/aliases.lua")
 
-if(minetest.get_modpath("bonemeal")) then
+if(core.get_modpath("bonemeal")) then
     bonemeal:add_crop(cucina_vegana.plant_settings.bonemeal_list)
 
 end -- if(cucina_vegana.plant_settings.bonemeal
 
-minetest.log("info", "[MOD] " .. modname .. " Version " .. cucina_vegana.version .. " loaded.")
+core.log("info", "[MOD] " .. modname .. " Version " .. cucina_vegana.version .. " loaded.")

--- a/intllib.lua
+++ b/intllib.lua
@@ -22,7 +22,7 @@ local function format(str, ...)
 end
 
 local gettext, ngettext
-if minetest.get_modpath("intllib") then
+if core.get_modpath("intllib") then
 	if intllib.make_gettext_pair then
 		-- New method using gettext.
 		gettext, ngettext = intllib.make_gettext_pair()

--- a/items.lua
+++ b/items.lua
@@ -9,140 +9,140 @@ local S = cucina_vegana.get_translator
 --   *****           Supports              *****
 --   *******************************************
 
-minetest.register_craftitem("cucina_vegana:blueberry_puree", {
+core.register_craftitem("cucina_vegana:blueberry_puree", {
 	description = S("Blueberry puree"),
 	inventory_image = "cucina_vegana_blueberry_puree.png",
 	groups = {food = 1, food_blueberry = 1, food_berry = 1},
-    on_use = minetest.item_eat(4)
+    on_use = core.item_eat(4)
 })
 
-minetest.register_craftitem("cucina_vegana:blueberry_pot", {
+core.register_craftitem("cucina_vegana:blueberry_pot", {
 	description = S("Blueberry pot"),
 	inventory_image = "cucina_vegana_blueberry_pot.png",
 	groups = {sud = 1},
 })
 
-minetest.register_craftitem("cucina_vegana:blueberry_pot_cooked", {
+core.register_craftitem("cucina_vegana:blueberry_pot_cooked", {
 	description = S("Blueberry pot (cooked)"),
 	inventory_image = "cucina_vegana_blueberry_pot_cooked.png",
 	groups = {sud = 1},
 })
 
-minetest.register_craftitem("cucina_vegana:bread_garlic", {
+core.register_craftitem("cucina_vegana:bread_garlic", {
 	description = S("Garlicbread Dough"),
 	inventory_image = "cucina_vegana_bread_garlic.png",
 	groups = {food = 1, bread_dough = 1},
 })
 
-minetest.register_craftitem("cucina_vegana:ciabatta_dough", {
+core.register_craftitem("cucina_vegana:ciabatta_dough", {
 	description = S("Ciabatta dough"),
 	inventory_image = "cucina_vegana_ciabatta_dough.png",
 	groups = {food = 1, bread_dough = 1},
 })
 
-minetest.register_craftitem("cucina_vegana:dandelion_honey", {
+core.register_craftitem("cucina_vegana:dandelion_honey", {
 	description = S("Dandelion Honey"),
 	inventory_image = "cucina_vegana_dandelion_honey.png",
 	groups = {flammable = 1, food = 1, food_honey = 1, food_sugar = 1, eatable = 1},
-    on_use = minetest.item_eat(3),
+    on_use = core.item_eat(3),
 })
 
-minetest.register_craftitem("cucina_vegana:dandelion_suds", {
+core.register_craftitem("cucina_vegana:dandelion_suds", {
 	description = S("Dandelion Suds"),
 	inventory_image = "cucina_vegana_dandelion_suds.png",
 	groups = {sud = 1,},
 })
 
-minetest.register_craftitem("cucina_vegana:dandelion_suds_cooking", {
+core.register_craftitem("cucina_vegana:dandelion_suds_cooking", {
 	description = S("Dandelion Suds (cooking)"),
 	inventory_image = "cucina_vegana_dandelion_suds_cooking.png",
 	groups = {sud = 1,},
 })
 
-minetest.register_craftitem("cucina_vegana:molasses", {
+core.register_craftitem("cucina_vegana:molasses", {
 	description = S("Molasses"),
 	inventory_image = "cucina_vegana_molasses.png",
 	groups = {flammable = 1, food = 1, food_sugar = 1},
 })
 
-minetest.register_craftitem("cucina_vegana:pizza_dough", {
+core.register_craftitem("cucina_vegana:pizza_dough", {
 	description = S("Pizzadough"),
 	inventory_image = "cucina_vegana_pizza_dough.png",
 	groups = {food = 1, pizza_dough = 1},
 })
 
-minetest.register_craftitem("cucina_vegana:rice_flour", {
+core.register_craftitem("cucina_vegana:rice_flour", {
     description = S("Rice Flour"),
     groups = {food_vegan = 1, food_flour = 1},
     inventory_image = "cucina_vegana_rice_flour.png",
 })
 
-minetest.register_craftitem("cucina_vegana:rice_starch", {
+core.register_craftitem("cucina_vegana:rice_starch", {
     description = S("Rice Starch"),
     groups = {food_vegan = 1, food_starch = 1},
     inventory_image = "cucina_vegana_rice_starch.png",
 })
 
-minetest.register_craftitem("cucina_vegana:soy_milk", {
+core.register_craftitem("cucina_vegana:soy_milk", {
 	description = S("Soy Milk"),
 	inventory_image = "cucina_vegana_soy_milk.png",
 	groups = {flammable = 1, food = 1, food_milk = 1, eatable = 1, food_vegan = 1},
-	on_use = minetest.item_eat(2, "vessels:drinking_glass"),
+	on_use = core.item_eat(2, "vessels:drinking_glass"),
 })
 
-minetest.register_craftitem("cucina_vegana:sunflower_seeds_dough", {
+core.register_craftitem("cucina_vegana:sunflower_seeds_dough", {
     description = S("Sunflower Seeds Dough"),
     groups = {food = 1, food_vegan = 1, eatable = 1, bread_dough = 1},
     inventory_image = "cucina_vegana_sunflower_seeds_dough.png",
-    on_use = minetest.item_eat(2),
+    on_use = core.item_eat(2),
 })
 
-minetest.register_craftitem("cucina_vegana:sunflower_seeds_flour", {
+core.register_craftitem("cucina_vegana:sunflower_seeds_flour", {
     description = S("Sunflower Seeds Flour"),
     groups = {food_vegan = 1, food_flour = 1},
     inventory_image = "cucina_vegana_sunflower_seeds_flour.png",
 })
 
-minetest.register_craftitem("cucina_vegana:tofu", {
+core.register_craftitem("cucina_vegana:tofu", {
 	description = S("Tofu (raw)"),
 	inventory_image = "cucina_vegana_tofu.png",
 	groups = {flammable = 1, food = 1, eatable = 1, food_vegan = 1},
-	on_use = minetest.item_eat(2),
+	on_use = core.item_eat(2),
 })
 
 --   *******************************************
 --   *****           Imitations            *****
 --   *******************************************
 
-minetest.register_craftitem("cucina_vegana:imitation_butter", {
+core.register_craftitem("cucina_vegana:imitation_butter", {
 	description = S("Imitation Butter"),
 	groups = {food = 1, food_butter = 1, food_vegan = 1, eatable = 1},
 	inventory_image = "cucina_vegana_imitation_butter.png",
-	on_use = minetest.item_eat(2),
+	on_use = core.item_eat(2),
 })
 
-minetest.register_craftitem("cucina_vegana:imitation_cheese", {
+core.register_craftitem("cucina_vegana:imitation_cheese", {
 	description = S("Imitation Cheese"),
 	groups = {food = 1, food_cheese = 1, food_vegan = 1, eatable = 1},
 	inventory_image = "cucina_vegana_imitation_cheese.png",
-	on_use = minetest.item_eat(3),
+	on_use = core.item_eat(3),
 })
 
-minetest.register_craftitem("cucina_vegana:imitation_fish", {
+core.register_craftitem("cucina_vegana:imitation_fish", {
 	description = S("Imitation Fish"),
 	groups = {food = 1, food_fish = 1, food_vegan = 1, eatable = 1},
 	inventory_image = "cucina_vegana_imitation_fish.png",
-	on_use = minetest.item_eat(3),
+	on_use = core.item_eat(3),
 })
 
-minetest.register_craftitem("cucina_vegana:imitation_meat", {
+core.register_craftitem("cucina_vegana:imitation_meat", {
 	description = S("Imitation Meat"),
 	groups = {food = 1, food_meat = 1, food_vegan = 1, eatable = 1, food_meat_raw = 1},
 	inventory_image = "cucina_vegana_imitation_meat.png",
-	on_use = minetest.item_eat(3),
+	on_use = core.item_eat(3),
 })
 
-minetest.register_craftitem("cucina_vegana:imitation_poultry", {
+core.register_craftitem("cucina_vegana:imitation_poultry", {
 	description = S("Imitation poultry"),
 	groups = {food = 1, food_bird = 1, food_vegan = 1},
 	inventory_image = "cucina_vegana_imitation_poultry.png",
@@ -152,229 +152,229 @@ minetest.register_craftitem("cucina_vegana:imitation_poultry", {
 --   *****             Crops               *****
 --   *******************************************
 
-minetest.register_craftitem("cucina_vegana:asparagus", {
+core.register_craftitem("cucina_vegana:asparagus", {
 	description = S("Asparagus"),
 	inventory_image = "cucina_vegana_asparagus.png",
 	groups = {flammable = 1, food = 1, eatable = 1, food_vegan = 1, food_asparagus = 1},
-	on_use = minetest.item_eat(3),
+	on_use = core.item_eat(3),
 })
 
-minetest.register_craftitem("cucina_vegana:banana", {
+core.register_craftitem("cucina_vegana:banana", {
 	description = S("Banana"),
 	inventory_image = "cucina_vegana_banana.png",
 	groups = {flammable = 1, food = 1, eatable = 1, food_vegan = 1, food_banana = 1},
-	on_use = minetest.item_eat(4),
+	on_use = core.item_eat(4),
 })
 
-minetest.register_craftitem("cucina_vegana:chives", {
+core.register_craftitem("cucina_vegana:chives", {
 	description = S("Chives"),
 	inventory_image = "cucina_vegana_chives.png",
 	groups = {flammable = 1, food = 1, eatable = 1, food_vegan = 1, food_chives = 1},
-	on_use = minetest.item_eat(1),
+	on_use = core.item_eat(1),
 })
 
-minetest.register_craftitem("cucina_vegana:coffee_beans_raw", {
+core.register_craftitem("cucina_vegana:coffee_beans_raw", {
 	description = S("Coffee Beans raw"),
 	inventory_image = "cucina_vegana_coffee_beans_raw.png",
 	groups = {flammable = 1, food_coffee = 1},
 })
 
-minetest.register_craftitem("cucina_vegana:coffee_beans_roasted", {
+core.register_craftitem("cucina_vegana:coffee_beans_roasted", {
 	description = S("Coffee Beans"),
 	inventory_image = "cucina_vegana_coffee_beans_roasted.png",
 	groups = {flammable = 1, food = 1, eatable = 1, food_vegan = 1, food_coffee = 1},
-	on_use = minetest.item_eat(.5),
+	on_use = core.item_eat(.5),
 })
 
-minetest.register_craftitem("cucina_vegana:coffee_powder", {
+core.register_craftitem("cucina_vegana:coffee_powder", {
 	description = S("Coffee Powder"),
 	inventory_image = "cucina_vegana_coffee_powder.png",
 	groups = {flammable = 1, food_coffee = 1},
 })
 
-minetest.register_craftitem("cucina_vegana:flax", {
+core.register_craftitem("cucina_vegana:flax", {
 	description = S("Flax (raw)"),
 	inventory_image = "cucina_vegana_flax_raw.png",
 	groups = {flammable = 1, string = 1},
 })
 
-minetest.register_craftitem("cucina_vegana:flax_roasted", {
+core.register_craftitem("cucina_vegana:flax_roasted", {
 	description = S("Flax"),
 	inventory_image = "cucina_vegana_flax.png",
 	groups = {flammable = 1, string = 1},
 })
 
-minetest.register_craftitem("cucina_vegana:kohlrabi", {
+core.register_craftitem("cucina_vegana:kohlrabi", {
 	description = S("Kohlrabi"),
 	inventory_image = "cucina_vegana_kohlrabi.png",
 	groups = {flammable = 1, food = 1, eatable = 1, food_vegan = 1, food_kohlrabi = 1},
-	on_use = minetest.item_eat(3),
+	on_use = core.item_eat(3),
 })
 
-minetest.register_craftitem("cucina_vegana:lettuce", {
+core.register_craftitem("cucina_vegana:lettuce", {
 	description = S("Lettuce"),
 	inventory_image = "cucina_vegana_lettuce.png",
 	groups = {flammable = 1, food = 1, eatable = 1, food_vegan = 1, food_lettuce = 1},
-	on_use = minetest.item_eat(2),
+	on_use = core.item_eat(2),
 })
 
-minetest.register_craftitem("cucina_vegana:parsley", {
+core.register_craftitem("cucina_vegana:parsley", {
 	description = S("Parsley"),
 	inventory_image = "cucina_vegana_parsley.png",
 	groups = {flammable = 1, food = 1, eatable = 1, food_vegan = 1, food_parsley = 1},
-	on_use = minetest.item_eat(1),
+	on_use = core.item_eat(1),
 })
 
-minetest.register_craftitem("cucina_vegana:peanut", {
+core.register_craftitem("cucina_vegana:peanut", {
 	description = S("Peanut"),
 	inventory_image = "cucina_vegana_peanut.png",
 	groups = {flammable = 1, food = 1, eatable = 1, food_vegan = 1, food_peanut = 1},
-	on_use = minetest.item_eat(4),
+	on_use = core.item_eat(4),
 })
 
-minetest.register_craftitem("cucina_vegana:rice", {
+core.register_craftitem("cucina_vegana:rice", {
     description = S("Rice"),
     inventory_image = "cucina_vegana_rice.png",
     groups = {food = 1, flammable = 4, food_rice = 1},
 })
 
-minetest.register_craftitem("cucina_vegana:rosemary", {
+core.register_craftitem("cucina_vegana:rosemary", {
 	description = S("Rosemary Twig"),
 	inventory_image = "cucina_vegana_rosemary.png",
 	groups = {flammable = 1, food = 1, eatable = 1, food_rosemary = 1},
-	on_use = minetest.item_eat(1),
+	on_use = core.item_eat(1),
 })
 
-minetest.register_craftitem("cucina_vegana:soy", {
+core.register_craftitem("cucina_vegana:soy", {
 	description = S("Soy Bean"),
 	inventory_image = "cucina_vegana_soy.png",
 	groups = {flammable = 4, food_soy = 1},
 })
 
-minetest.register_craftitem("cucina_vegana:sunflower", {
+core.register_craftitem("cucina_vegana:sunflower", {
     description = S("Sunflower"),
     inventory_image = "cucina_vegana_sunflower.png",
     groups = {flammable = 4},
 })
 
-minetest.register_craftitem("cucina_vegana:sunflower_seeds", {
+core.register_craftitem("cucina_vegana:sunflower_seeds", {
     description = S("Sunflower Seeds"),
     groups = {seed = 1, food = 1, eatable = 1, food_sunflower = 1},
     inventory_image = "cucina_vegana_sunflower_seeds.png",
-    on_use = minetest.item_eat(1),
+    on_use = core.item_eat(1),
 })
 
-minetest.register_craftitem("cucina_vegana:tomato", {
+core.register_craftitem("cucina_vegana:tomato", {
 	description = S("Tomato"),
 	inventory_image = "cucina_vegana_tomato.png",
 	groups = {flammable = 1, food = 1, eatable = 1, food_vegan = 1, food_tomato = 1},
-	on_use = minetest.item_eat(4),
+	on_use = core.item_eat(4),
 })
 
-minetest.register_craftitem("cucina_vegana:potato", {
+core.register_craftitem("cucina_vegana:potato", {
 	description = S("Potato"),
 	inventory_image = "cucina_vegana_potato.png",
 	groups = {flammable = 1, food = 1, eatable = 1, food_vegan = 1, food_potato = 1},
-	on_use = minetest.item_eat(5),
+	on_use = core.item_eat(5),
 })
 
-minetest.register_craftitem("cucina_vegana:carrot", {
+core.register_craftitem("cucina_vegana:carrot", {
 	description = S("Carrot"),
 	inventory_image = "cucina_vegana_carrot.png",
 	groups = {flammable = 1, food = 1, eatable = 1, food_vegan = 1, food_carrot = 1},
-	on_use = minetest.item_eat(3),
+	on_use = core.item_eat(3),
 })
 
-minetest.register_craftitem("cucina_vegana:garlic", {
+core.register_craftitem("cucina_vegana:garlic", {
 	description = S("Garlic"),
 	inventory_image = "cucina_vegana_garlic.png",
 	groups = {flammable = 1, food = 1, food_vegan = 1, food_garlic = 1},
 })
 
-minetest.register_craftitem("cucina_vegana:chili", {
+core.register_craftitem("cucina_vegana:chili", {
 	description = S("Chili"),
 	inventory_image = "cucina_vegana_chili.png",
 	groups = {flammable = 1, food = 1, food_vegan = 1, food_chili = 1},
-	on_use = minetest.item_eat(1),
+	on_use = core.item_eat(1),
 })
 
-minetest.register_craftitem("cucina_vegana:onion", {
+core.register_craftitem("cucina_vegana:onion", {
 	description = S("Onion"),
 	inventory_image = "cucina_vegana_onion.png",
 	groups = {flammable = 1, food = 1, food_vegan = 1, food_onion = 1},
-	on_use = minetest.item_eat(3),
+	on_use = core.item_eat(3),
 })
 
-minetest.register_craftitem("cucina_vegana:cucumber", {
+core.register_craftitem("cucina_vegana:cucumber", {
 	description = S("Cucumber"),
 	inventory_image = "cucina_vegana_cucumber.png",
 	groups = {flammable = 1, food = 1, food_vegan = 1, food_cucumber = 1},
-	on_use = minetest.item_eat(3),
+	on_use = core.item_eat(3),
 })
 
-minetest.register_craftitem("cucina_vegana:strawberry", {
+core.register_craftitem("cucina_vegana:strawberry", {
 	description = S("Strawberry"),
 	inventory_image = "cucina_vegana_strawberry.png",
 	groups = {flammable = 1, food = 1, eatable = 1, food_vegan = 1, food_strawberry = 1},
-	on_use = minetest.item_eat(2),
+	on_use = core.item_eat(2),
 })
 
-minetest.register_craftitem("cucina_vegana:corn", {
+core.register_craftitem("cucina_vegana:corn", {
 	description = S("Corncob"),
 	inventory_image = "cucina_vegana_corn.png",
 	groups = {flammable = 1, food = 1, eatable = 1, food_vegan = 1, food_corn = 1},
-	on_use = minetest.item_eat(2),
+	on_use = core.item_eat(2),
 })
 
 --   *******************************************
 --   *****              Food               *****
 --   *******************************************
 
-minetest.register_craftitem("cucina_vegana:kohlrabi_roasted", {
+core.register_craftitem("cucina_vegana:kohlrabi_roasted", {
 	description = S("Roasted Kohlrabi"),
 	groups = {food = 1, eatable = 1},
 	inventory_image = "cucina_vegana_kohlrabi_roasted.png",
-	on_use = minetest.item_eat(4),
+	on_use = core.item_eat(4),
 })
 
-minetest.register_craftitem("cucina_vegana:sunflower_seeds_roasted", {
+core.register_craftitem("cucina_vegana:sunflower_seeds_roasted", {
 	description = S("Roasted Sunflower Seeds"),
 	groups = {food = 1, eatable = 1},
 	inventory_image = "cucina_vegana_sunflower_seeds_roasted.png",
-	on_use = minetest.item_eat(2),
+	on_use = core.item_eat(2),
 })
 
-minetest.register_craftitem("cucina_vegana:sunflower_seeds_bread", {
+core.register_craftitem("cucina_vegana:sunflower_seeds_bread", {
 	description = S("Sunflower Seeds Bread"),
 	groups = {food = 1, food_bread = 1, eatable = 1},
 	inventory_image = "cucina_vegana_sunflower_seeds_bread.png",
-	on_use = minetest.item_eat(4),
+	on_use = core.item_eat(4),
 })
 
-minetest.register_craftitem("cucina_vegana:bread_garlic_cooked", {
+core.register_craftitem("cucina_vegana:bread_garlic_cooked", {
 	description = S("Garlicbread fresh"),
 	groups = {food = 1, food_bread = 1, eatable = 1},
 	inventory_image = "cucina_vegana_bread_garlic_cooked.png",
-	on_use = minetest.item_eat(4),
+	on_use = core.item_eat(4),
 })
 
-minetest.register_craftitem("cucina_vegana:tofu_cooked", {
+core.register_craftitem("cucina_vegana:tofu_cooked", {
 	description = S("Tofu"),
 	inventory_image = "cucina_vegana_tofu_cooked.png",
 	groups = {flammable = 1, food = 1, eatable = 1, food_vegan = 1, food_tofu = 1},
-	on_use = minetest.item_eat(3),
+	on_use = core.item_eat(3),
 })
 
-minetest.register_craftitem("cucina_vegana:vegan_sushi", {
+core.register_craftitem("cucina_vegana:vegan_sushi", {
 	description = S("Vegan Sushi"),
 	groups = {food = 1, food_vegan = 1, eatable = 1},
 	inventory_image = "cucina_vegana_vegan_sushi.png",
-	on_use = minetest.item_eat(4),
+	on_use = core.item_eat(4),
 })
 
-minetest.register_craftitem("cucina_vegana:vegan_strawberry_milk", {
+core.register_craftitem("cucina_vegana:vegan_strawberry_milk", {
 	description = S("Vegan Strawberry Milk"),
 	groups = {food = 1, food_vegan = 1, eatable = 1},
 	inventory_image = "cucina_vegana_vegan_strawberry_milk.png",
-	on_use = minetest.item_eat(3, "vessels:drinking_glass"),
+	on_use = core.item_eat(3, "vessels:drinking_glass"),
 })

--- a/kohlrabi.lua
+++ b/kohlrabi.lua
@@ -23,7 +23,7 @@ farming.register_plant("cucina_vegana:" .. pname, {
 })
 
 -- Register for Mapgen
-minetest.register_node("cucina_vegana:wild_" .. pname, {
+core.register_node("cucina_vegana:wild_" .. pname, {
 	description = S("Wild") .. " " .. dname,
 	paramtype = "light",
 	walkable = false,
@@ -48,9 +48,9 @@ minetest.register_node("cucina_vegana:wild_" .. pname, {
 	},
 })
 
-minetest.register_alias("kohlrabi:kohlrabi", "cucina_vegana:" .. pname)
-minetest.register_alias("kohlrabi:seed", "cucina_vegana:" .. pname .. "_seed")
-minetest.register_alias("kohlrabi:wild_kohlrabi", "cucina_vegana:wild_" .. pname)
+core.register_alias("kohlrabi:kohlrabi", "cucina_vegana:" .. pname)
+core.register_alias("kohlrabi:seed", "cucina_vegana:" .. pname .. "_seed")
+core.register_alias("kohlrabi:wild_kohlrabi", "cucina_vegana:wild_" .. pname)
 
 if(cucina_vegana.plant_settings.bonemeal) then
     table.insert(cucina_vegana.plant_settings.bonemeal_list,
@@ -70,7 +70,7 @@ if(cucina_vegana.signs_bot) then
 
 end
 
-minetest.register_decoration({
+core.register_decoration({
 	deco_type = "simple",
 	place_on = {"default:dirt_with_grass", "default:dirt_with_dry_grass"},
 	sidelen = 16,

--- a/lettuce.lua
+++ b/lettuce.lua
@@ -23,7 +23,7 @@ farming.register_plant("cucina_vegana:" .. pname, {
 })
 
 -- Register for Mapgen
-minetest.register_node("cucina_vegana:wild_" .. pname, {
+core.register_node("cucina_vegana:wild_" .. pname, {
 	description = S("Wild") .. " " ..dname,
 	paramtype = "light",
 	walkable = false,
@@ -51,9 +51,9 @@ minetest.register_node("cucina_vegana:wild_" .. pname, {
 cucina_vegana.add_group("cucina_vegana:seed_" .. pname, {seed_lettuce = 1})
 
 -- Register Recipe for Oil
-minetest.register_alias("lettuce:lettuce", "cucina_vegana:" .. pname)
-minetest.register_alias("lettuce:seed", "cucina_vegana:" .. pname .. "_seed")
-minetest.register_alias("lettuce:wild_lettuce", "cucina_vegana:wild_" .. pname)
+core.register_alias("lettuce:lettuce", "cucina_vegana:" .. pname)
+core.register_alias("lettuce:seed", "cucina_vegana:" .. pname .. "_seed")
+core.register_alias("lettuce:wild_lettuce", "cucina_vegana:wild_" .. pname)
 
 if(cucina_vegana.plant_settings.bonemeal) then
     table.insert(cucina_vegana.plant_settings.bonemeal_list,
@@ -73,7 +73,7 @@ if(cucina_vegana.signs_bot) then
 
 end
 
-minetest.register_decoration({
+core.register_decoration({
 	deco_type = "simple",
 	place_on = {"default:dirt_with_grass", "default:dirt_with_dry_grass"},
 	sidelen = 16,

--- a/lib.lua
+++ b/lib.lua
@@ -6,15 +6,14 @@
 ]]--
 
 local cv = cucina_vegana
-local mt = minetest
 local S = cv.get_translator
 math.randomseed(os.time())
 
 function cv.lib.register_bottom_abm(node, nextnode, duration, light)
     local percent = 1
 
-    if(mt.registered_nodes[node]) then
-        mt.register_abm({
+    if(core.registered_nodes[node]) then
+        core.register_abm({
             nodenames = {node},
             interval = duration,
             chance = percent,
@@ -23,7 +22,7 @@ function cv.lib.register_bottom_abm(node, nextnode, duration, light)
                         local nodepos = pos
                         if(cv.lib.check_soil(nodepos)) then
                             if(cv.lib.check_light(nodepos, light)) then
-                                mt.set_node(nodepos, {name = nextnode})
+                                core.set_node(nodepos, {name = nextnode})
 
                             end -- if(cv.check_light
 
@@ -31,7 +30,7 @@ function cv.lib.register_bottom_abm(node, nextnode, duration, light)
 
                     end, -- function(
 
-        }) -- minetest.register_abm({
+        }) -- core.register_abm({
 
     end -- if(nodename ~= nil
 
@@ -40,8 +39,8 @@ end
 function cv.lib.register_top_abm(node, nextnode, duration, light)
     local percent = 1
 
-    if(mt.registered_nodes[node]) then
-        mt.register_abm({
+    if(core.registered_nodes[node]) then
+        core.register_abm({
             nodenames = {node},
             interval = duration,
             chance = percent,
@@ -49,26 +48,26 @@ function cv.lib.register_top_abm(node, nextnode, duration, light)
             action = function(pos, node, active_object_count, active_object_count_wider)
                         local nodepos = pos
                             if(cv.lib.check_light(nodepos, light)) then
-                                mt.set_node(nodepos, {name = nextnode})
+                                core.set_node(nodepos, {name = nextnode})
 
                             end -- if(cv.check_light
 
                     end, -- function(
 
-        }) -- minetest.register_abm({
+        }) -- core.register_abm({
 
     end -- if(nodename ~= nil
 
 end
 
 function cv.lib.check_light(pos, level)
-    local node = mt.get_node_or_nil(pos)
+    local node = core.get_node_or_nil(pos)
 
     if(node) then
-        local light = mt.get_node_light(pos) or 0
+        local light = core.get_node_light(pos) or 0
         if(light >= level) then return true end
 
-    end -- if(minetest.get_node_or_nil(
+    end -- if(core.get_node_or_nil(
 
     return false
 
@@ -76,19 +75,19 @@ end -- function aqua_farming.check_light
 
 function cv.lib.check_soil(pos)
     local below = {x = pos.x, y = pos.y - 1, z = pos.z}
-    local soil = mt.get_node_or_nil(below)
+    local soil = core.get_node_or_nil(below)
 
-    if(soil and mt.get_item_group(soil, "group:soil")) then
+    if(soil and core.get_item_group(soil, "group:soil")) then
         return true
 
-    end -- if(minetest.get_node_or_nil(
+    end -- if(core.get_node_or_nil(
 
     return false
 
 end -- cv.lib.check_soil
 
 function cv.lib.check_air(pos)
-    local air = mt.get_node_or_nil(pos)
+    local air = core.get_node_or_nil(pos)
     if (air) and (string.match(air.name,"air")) then
         return true
 
@@ -107,20 +106,20 @@ function cv.lib.coffee_effect(playerobject)
     local normalspeed = 1
 
     playerobject:set_physics_override({speed = highspeed})
-    minetest.chat_send_player(playername, S("Coffeespeed. @1 Seconds left.", seconds))
+    core.chat_send_player(playername, S("Coffeespeed. @1 Seconds left.", seconds))
 
-    minetest.after(seconds/2, function()
-                                    local playerobject = minetest.get_player_by_name(playername)
+    core.after(seconds/2, function()
+                                    local playerobject = core.get_player_by_name(playername)
                                     if(not playerobject) then return end
 
-                                    minetest.chat_send_player(playername,S("@1 Seconds left.", seconds/2))
+                                    core.chat_send_player(playername,S("@1 Seconds left.", seconds/2))
                               end, playername)
 
-    minetest.after(seconds, function()
-                                    local playerobject = minetest.get_player_by_name(playername)
+    core.after(seconds, function()
+                                    local playerobject = core.get_player_by_name(playername)
                                     if(not playerobject) then return end
 
-                                    minetest.chat_send_player(playername,S("You move normal again."))
+                                    core.chat_send_player(playername,S("You move normal again."))
                                     playerobject:set_physics_override({speed = normalspeed})
                            end, playername)
 

--- a/mod.conf
+++ b/mod.conf
@@ -1,5 +1,5 @@
 name = cucina_vegana
-description = A mod which the vegan kitchen to Minetest.
+description = A mod which the vegan kitchen to Luanti.
 depends = default,dye,farming,vessels
 optional_depends = basic_materials, bbq,bees,bonemeal,bucket,building_blocks,bushes,bushes_classic,cottages,farming_redo,farming_nextgen,fishing,flowers,hunger, hunger_ng,homedecor,intllib,mobs,moreblocks,pizza,ropes,technic,wine,wool,petz,lemontree,clementinetree,hunger_ng,aqua_farming,signs_bot,techage,diet
 min_minetest_version = 5.0

--- a/nodes.lua
+++ b/nodes.lua
@@ -10,7 +10,7 @@ local cv = cucina_vegana
 --   *****           Supports              *****
 --   *******************************************
 
-minetest.register_node("cucina_vegana:bowl", {
+core.register_node("cucina_vegana:bowl", {
 	description = S("Glass Bowl"),
 	drawtype = "plantlike",
 	tiles = {"cucina_vegana_bowl.png"},
@@ -27,7 +27,7 @@ minetest.register_node("cucina_vegana:bowl", {
 	sounds = default.node_sound_glass_defaults(),
 })
 
-minetest.register_node("cucina_vegana:flax_seed_oil", {
+core.register_node("cucina_vegana:flax_seed_oil", {
 	description = S("Bottle of Flaxseed Oil"),
 	drawtype = "plantlike",
 	tiles = {"cucina_vegana_flax_seed_oil.png"},
@@ -36,7 +36,7 @@ minetest.register_node("cucina_vegana:flax_seed_oil", {
 	paramtype = "light",
 	is_ground_content = false,
 	walkable = false,
-	on_use = minetest.item_eat(2, "vessels:glass_bottle"),
+	on_use = core.item_eat(2, "vessels:glass_bottle"),
 	selection_box = {
 		type = "fixed",
 		fixed = {-0.25, -0.5, -0.25, 0.25, 0.3, 0.25}
@@ -45,7 +45,7 @@ minetest.register_node("cucina_vegana:flax_seed_oil", {
 	sounds = default.node_sound_glass_defaults(),
 })
 
-minetest.register_node("cucina_vegana:mushroomlight_glass", {
+core.register_node("cucina_vegana:mushroomlight_glass", {
 	description = S("Mushroomlight Glass"),
 	drawtype = "glasslike_framed_optional",
 	tiles = {"cucina_vegana_mushroom_light.png","cucina_vegana_mushroom_light_detail.png"},
@@ -58,7 +58,7 @@ minetest.register_node("cucina_vegana:mushroomlight_glass", {
 	sounds = default.node_sound_glass_defaults()
 })
 
-minetest.register_node("cucina_vegana:peanut_oil", {
+core.register_node("cucina_vegana:peanut_oil", {
 	description = S("Bottle of Peanut Oil"),
 	drawtype = "plantlike",
 	tiles = {"cucina_vegana_peanut_oil.png"},
@@ -67,7 +67,7 @@ minetest.register_node("cucina_vegana:peanut_oil", {
 	paramtype = "light",
 	is_ground_content = false,
 	walkable = false,
-	on_use = minetest.item_eat(5, "vessels:glass_bottle"),
+	on_use = core.item_eat(5, "vessels:glass_bottle"),
 	selection_box = {
 		type = "fixed",
 		fixed = {-0.25, -0.5, -0.25, 0.25, 0.3, 0.25}
@@ -76,7 +76,7 @@ minetest.register_node("cucina_vegana:peanut_oil", {
 	sounds = default.node_sound_glass_defaults(),
 })
 
-minetest.register_node("cucina_vegana:plate", {
+core.register_node("cucina_vegana:plate", {
 	description = S("Plate"),
 	drawtype = "plantlike",
 	tiles = {"cucina_vegana_plate.png"},
@@ -93,7 +93,7 @@ minetest.register_node("cucina_vegana:plate", {
 	sounds = default.node_sound_glass_defaults(),
 })
 
-minetest.register_node("cucina_vegana:sunflower_seeds_oil", {
+core.register_node("cucina_vegana:sunflower_seeds_oil", {
 	description = S("Bottle of Sunflower Seeds Oil"),
 	drawtype = "plantlike",
 	tiles = {"cucina_vegana_sunflower_seeds_oil.png"},
@@ -102,7 +102,7 @@ minetest.register_node("cucina_vegana:sunflower_seeds_oil", {
 	paramtype = "light",
 	is_ground_content = false,
 	walkable = false,
-	on_use = minetest.item_eat(2, "vessels:glass_bottle"),
+	on_use = core.item_eat(2, "vessels:glass_bottle"),
 	selection_box = {
 		type = "fixed",
 		fixed = {-0.25, -0.5, -0.25, 0.25, 0.3, 0.25}
@@ -111,7 +111,7 @@ minetest.register_node("cucina_vegana:sunflower_seeds_oil", {
 	sounds = default.node_sound_glass_defaults(),
 })
 
-minetest.register_node("cucina_vegana:corn_oil", {
+core.register_node("cucina_vegana:corn_oil", {
 	description = S("Bottle of Corn Oil"),
 	drawtype = "plantlike",
 	tiles = {"cucina_vegana_corn_oil.png"},
@@ -120,7 +120,7 @@ minetest.register_node("cucina_vegana:corn_oil", {
 	paramtype = "light",
 	is_ground_content = false,
 	walkable = false,
-	on_use = minetest.item_eat(2, "vessels:glass_bottle"),
+	on_use = core.item_eat(2, "vessels:glass_bottle"),
 	selection_box = {
 		type = "fixed",
 		fixed = {-0.25, -0.5, -0.25, 0.25, 0.3, 0.25}
@@ -133,7 +133,7 @@ minetest.register_node("cucina_vegana:corn_oil", {
 --   *****       Síde Dishes               *****
 --   *******************************************
 
-minetest.register_node("cucina_vegana:blueberry_jam", {
+core.register_node("cucina_vegana:blueberry_jam", {
 	description = S("Blueberry Jam"),
 	drawtype = "plantlike",
 	tiles = {"cucina_vegana_blueberry_jam.png"},
@@ -141,7 +141,7 @@ minetest.register_node("cucina_vegana:blueberry_jam", {
 	wield_image = "cucina_vegana_blueberry_jam.png",
 	paramtype = "light",
 	is_ground_content = false,
-	on_use = minetest.item_eat(8),
+	on_use = core.item_eat(8),
 	walkable = false,
 	selection_box = {
 		type = "fixed",
@@ -150,7 +150,7 @@ minetest.register_node("cucina_vegana:blueberry_jam", {
 	groups = {dig_immediate = 3, attached_node = 1, food_vegan = 1, food_sweet = 1, eatable = 1},
 })
 
-minetest.register_node("cucina_vegana:coffee_cup", {
+core.register_node("cucina_vegana:coffee_cup", {
 	description = S("Cup of Coffee cold"),
 	drawtype = "mesh",
 	mesh = "cucina_vegana_coffee_cup.obj",
@@ -161,7 +161,7 @@ minetest.register_node("cucina_vegana:coffee_cup", {
 	wield_image = "cucina_vegana_coffee_cup_inv.png",
 	paramtype = "light",
 	is_ground_content = false,
-	on_use = minetest.item_eat(2),
+	on_use = core.item_eat(2),
 	paramtype2 = "facedir",
 	param2 = "4dir",
 	walkable = true,
@@ -172,7 +172,7 @@ minetest.register_node("cucina_vegana:coffee_cup", {
 	groups = {dig_immediate = 3, attached_node = 1, food_vegan = 1, eatable = 1},
 })
 
-minetest.register_node("cucina_vegana:coffee_cup_hot", {
+core.register_node("cucina_vegana:coffee_cup_hot", {
 	description = S("Cup of Coffee hot"),
 	drawtype = "mesh",
 	mesh = "cucina_vegana_coffee_cup.obj",
@@ -201,7 +201,7 @@ minetest.register_node("cucina_vegana:coffee_cup_hot", {
 	on_use = function(itemstack, playerobject, pointed_thing)
 				if (not playerobject) then return end
 
-				minetest.item_eat(2)
+				core.item_eat(2)
 				cv.lib.coffee_effect(playerobject)
 				itemstack:take_item(1)
 				return itemstack
@@ -214,7 +214,7 @@ minetest.register_node("cucina_vegana:coffee_cup_hot", {
 	groups = {dig_immediate = 3, attached_node = 1, food_vegan = 1, eatable = 1},
 })
 
-minetest.register_node("cucina_vegana:cucumber_in_glass", {
+core.register_node("cucina_vegana:cucumber_in_glass", {
 	description = S("Cucumber in Glass"),
 	drawtype = "plantlike",
 	tiles = {"cucina_vegana_cucumber_in_glass.png"},
@@ -222,7 +222,7 @@ minetest.register_node("cucina_vegana:cucumber_in_glass", {
 	wield_image = "cucina_vegana_cucumber_in_glass.png",
 	paramtype = "light",
 	is_ground_content = false,
-	on_use = minetest.item_eat(5),
+	on_use = core.item_eat(5),
 	walkable = false,
 	selection_box = {
 		type = "fixed",
@@ -231,7 +231,7 @@ minetest.register_node("cucina_vegana:cucumber_in_glass", {
 	groups = {dig_immediate = 3, attached_node = 1, food_vegan = 1, eatable = 1},
 })
 
-minetest.register_node("cucina_vegana:ciabatta_bread", {
+core.register_node("cucina_vegana:ciabatta_bread", {
 	description = S("Ciabatta Bread"),
 	drawtype = "plantlike",
 	tiles = {"cucina_vegana_ciabatta_bread.png"},
@@ -239,7 +239,7 @@ minetest.register_node("cucina_vegana:ciabatta_bread", {
 	wield_image = "cucina_vegana_ciabatta_bread.png",
 	paramtype = "light",
 	is_ground_content = false,
-	on_use = minetest.item_eat(4),
+	on_use = core.item_eat(4),
 	walkable = false,
 	selection_box = {
 		type = "fixed",
@@ -248,7 +248,7 @@ minetest.register_node("cucina_vegana:ciabatta_bread", {
 	groups = {dig_immediate = 3, attached_node = 1, food_bread = 1, food_vegan = 1, eatable = 1},
 })
 
-minetest.register_node("cucina_vegana:edamame", {
+core.register_node("cucina_vegana:edamame", {
 	description = S("Edamame (raw)"),
 	drawtype = "plantlike",
 	tiles = {"cucina_vegana_edamame.png"},
@@ -265,13 +265,13 @@ minetest.register_node("cucina_vegana:edamame", {
 	sounds = default.node_sound_glass_defaults(),
 })
 
-minetest.register_node("cucina_vegana:edamame_cooked", {
+core.register_node("cucina_vegana:edamame_cooked", {
 	description = S("Edamame"),
 	drawtype = "plantlike",
 	tiles = {"cucina_vegana_edamame_cooked.png"},
 	inventory_image = "cucina_vegana_edamame_cooked.png",
 	wield_image = "cucina_vegana_edamame_cooked.png",
-	on_use = minetest.item_eat(4, "cucina_vegana:plate"),
+	on_use = core.item_eat(4, "cucina_vegana:plate"),
 	paramtype = "light",
 	is_ground_content = false,
 	walkable = false,
@@ -283,7 +283,7 @@ minetest.register_node("cucina_vegana:edamame_cooked", {
 	sounds = default.node_sound_glass_defaults(),
 })
 
-minetest.register_node("cucina_vegana:lettuce_oil", {
+core.register_node("cucina_vegana:lettuce_oil", {
 	description = S("Salad Oil"),
 	drawtype = "plantlike",
 	tiles = {"cucina_vegana_lettuce_oil.png"},
@@ -291,7 +291,7 @@ minetest.register_node("cucina_vegana:lettuce_oil", {
 	wield_image = "cucina_vegana_lettuce_oil.png",
 	paramtype = "light",
 	is_ground_content = false,
-	on_use = minetest.item_eat(2, "vessels:glass_bottle"),
+	on_use = core.item_eat(2, "vessels:glass_bottle"),
 	walkable = false,
 	selection_box = {
 		type = "fixed",
@@ -301,7 +301,7 @@ minetest.register_node("cucina_vegana:lettuce_oil", {
 	sounds = default.node_sound_glass_defaults(),
 })
 
-minetest.register_node("cucina_vegana:peanut_butter", {
+core.register_node("cucina_vegana:peanut_butter", {
 	description = S("Peanut Butter"),
 	drawtype = "plantlike",
 	tiles = {"cucina_vegana_peanut_butter.png"},
@@ -309,7 +309,7 @@ minetest.register_node("cucina_vegana:peanut_butter", {
 	wield_image = "cucina_vegana_peanut_butter.png",
 	paramtype = "light",
 	is_ground_content = false,
-	on_use = minetest.item_eat(10),
+	on_use = core.item_eat(10),
 	walkable = false,
 	selection_box = {
 		type = "fixed",
@@ -318,13 +318,13 @@ minetest.register_node("cucina_vegana:peanut_butter", {
 	groups = {dig_immediate = 3, attached_node = 1, food_vegan = 1, food_sweet = 1, food_butter = 1, eatable = 1},
 })
 
-minetest.register_node("cucina_vegana:salad_bowl", {
+core.register_node("cucina_vegana:salad_bowl", {
 	description = S("Glass Salad Bowl"),
 	drawtype = "plantlike",
 	tiles = {"cucina_vegana_salad_bowl.png"},
 	inventory_image = "cucina_vegana_salad_bowl.png",
 	wield_image = "cucina_vegana_salad_bowl.png",
-	on_use = minetest.item_eat(4, "cucina_vegana:bowl"),
+	on_use = core.item_eat(4, "cucina_vegana:bowl"),
 	paramtype = "light",
 	is_ground_content = false,
 	walkable = false,
@@ -336,7 +336,7 @@ minetest.register_node("cucina_vegana:salad_bowl", {
 	sounds = default.node_sound_glass_defaults(),
 })
 
-minetest.register_node("cucina_vegana:sauce_hollandaise", {
+core.register_node("cucina_vegana:sauce_hollandaise", {
 	description = S("Sauce Hollandaise"),
 	drawtype = "plantlike",
 	tiles = {"cucina_vegana_sauce_hollandaise.png"},
@@ -345,7 +345,7 @@ minetest.register_node("cucina_vegana:sauce_hollandaise", {
 	paramtype = "light",
 	is_ground_content = false,
 	walkable = false,
-	on_use = minetest.item_eat(3, "vessels:glass_bottle"),
+	on_use = core.item_eat(3, "vessels:glass_bottle"),
 	selection_box = {
 		type = "fixed",
 		fixed = {-0.25, -0.5, -0.25, 0.25, 0.3, 0.25}
@@ -354,13 +354,13 @@ minetest.register_node("cucina_vegana:sauce_hollandaise", {
 	sounds = default.node_sound_glass_defaults(),
 })
 
-minetest.register_node("cucina_vegana:sea_salad", {
+core.register_node("cucina_vegana:sea_salad", {
 	description = S("Sea Salad Bowl"),
 	drawtype = "plantlike",
 	tiles = {"cucina_vegana_sea_salad.png"},
 	inventory_image = "cucina_vegana_sea_salad.png",
 	wield_image = "cucina_vegana_sea_salad.png",
-	on_use = minetest.item_eat(5, "cucina_vegana:bowl"),
+	on_use = core.item_eat(5, "cucina_vegana:bowl"),
 	paramtype = "light",
 	is_ground_content = false,
 	walkable = false,
@@ -372,14 +372,14 @@ minetest.register_node("cucina_vegana:sea_salad", {
 	sounds = default.node_sound_glass_defaults(),
 })
 
-minetest.register_node("cucina_vegana:popcorn", {
+core.register_node("cucina_vegana:popcorn", {
 	description = S("Popcorn"),
 	drawtype = "plantlike",
 	tiles = {"cucina_vegana_popcorn.png"},
 	inventory_image = "cucina_vegana_popcorn.png",
 	wield_image = "cucina_vegana_popcorn.png",
 	paramtype2 = 3, -- #
-	on_use = minetest.item_eat(3),
+	on_use = core.item_eat(3),
 	paramtype = "light",
 	is_ground_content = false,
 	walkable = false,
@@ -395,7 +395,7 @@ minetest.register_node("cucina_vegana:popcorn", {
 --   *****           Dinners               *****
 --   *******************************************
 
-minetest.register_node("cucina_vegana:asparagus_hollandaise", {
+core.register_node("cucina_vegana:asparagus_hollandaise", {
 	description = S("Asparagus Hollandaise (raw)"),
 	drawtype = "plantlike",
 	tiles = {"cucina_vegana_asparagus_hollandaise.png"},
@@ -412,7 +412,7 @@ minetest.register_node("cucina_vegana:asparagus_hollandaise", {
 	sounds = default.node_sound_glass_defaults(),
 })
 
-minetest.register_node("cucina_vegana:asparagus_rice", {
+core.register_node("cucina_vegana:asparagus_rice", {
 	description = S("Asparagus on Rice (raw)"),
 	drawtype = "plantlike",
 	tiles = {"cucina_vegana_asparagus_rice.png"},
@@ -429,7 +429,7 @@ minetest.register_node("cucina_vegana:asparagus_rice", {
 	sounds = default.node_sound_glass_defaults(),
 })
 
-minetest.register_node("cucina_vegana:asparagus_soup", {
+core.register_node("cucina_vegana:asparagus_soup", {
 	description = S("Asparagus Soup (raw)"),
 	drawtype = "plantlike",
 	tiles = {"cucina_vegana_asparagus_soup.png"},
@@ -446,7 +446,7 @@ minetest.register_node("cucina_vegana:asparagus_soup", {
 	sounds = default.node_sound_glass_defaults(),
 })
 
-minetest.register_node("cucina_vegana:bowl_rice", {
+core.register_node("cucina_vegana:bowl_rice", {
 	description = S("Bowl of Rice (raw)"),
 	drawtype = "plantlike",
 	tiles = {"cucina_vegana_bowl_rice.png"},
@@ -463,7 +463,7 @@ minetest.register_node("cucina_vegana:bowl_rice", {
 	sounds = default.node_sound_glass_defaults(),
 })
 
-minetest.register_node("cucina_vegana:fish_parsley_rosemary", {
+core.register_node("cucina_vegana:fish_parsley_rosemary", {
 	description = S("Fish on Parsley and Rosemary (raw)"),
 	drawtype = "plantlike",
 	tiles = {"cucina_vegana_fish_parsley_rosemary.png"},
@@ -480,7 +480,7 @@ minetest.register_node("cucina_vegana:fish_parsley_rosemary", {
 	sounds = default.node_sound_glass_defaults(),
 })
 
-minetest.register_node("cucina_vegana:fryer_raw", {
+core.register_node("cucina_vegana:fryer_raw", {
 	description = S("Fryer (raw)"),
 	drawtype = "plantlike",
 	tiles = {"cucina_vegana_fryer_raw.png"},
@@ -496,7 +496,7 @@ minetest.register_node("cucina_vegana:fryer_raw", {
 	groups = {dig_immediate = 3, attached_node = 1, food_vegan = 1},
 })
 
-minetest.register_node("cucina_vegana:fryer", {
+core.register_node("cucina_vegana:fryer", {
 	description = S("Fryer"),
 	drawtype = "plantlike",
 	tiles = {"cucina_vegana_fryer.png"},
@@ -505,7 +505,7 @@ minetest.register_node("cucina_vegana:fryer", {
 	paramtype = "light",
 	is_ground_content = false,
 	walkable = false,
-	on_use = minetest.item_eat(8),
+	on_use = core.item_eat(8),
 	selection_box = {
 		type = "fixed",
 		fixed = {-0.25, -0.5, -0.25, 0.25, 0.3, 0.25}
@@ -513,7 +513,7 @@ minetest.register_node("cucina_vegana:fryer", {
 	groups = {dig_immediate = 3, attached_node = 1, food_vegan = 1, eatable = 1},
 })
 
-minetest.register_node("cucina_vegana:kohlrabi_soup", {
+core.register_node("cucina_vegana:kohlrabi_soup", {
 	description = S("Kohlrabi Soup (raw)"),
 	drawtype = "plantlike",
 	tiles = {"cucina_vegana_kohlrabi_soup.png"},
@@ -530,13 +530,13 @@ minetest.register_node("cucina_vegana:kohlrabi_soup", {
 	sounds = default.node_sound_glass_defaults(),
 })
 
-minetest.register_node("cucina_vegana:salad_hollandaise", {
+core.register_node("cucina_vegana:salad_hollandaise", {
 	description = S("Salad Bowl Hollandaise"),
 	drawtype = "plantlike",
 	tiles = {"cucina_vegana_salad_hollandaise.png"},
 	inventory_image = "cucina_vegana_salad_hollandaise.png",
 	wield_image = "cucina_vegana_salad_hollandaise.png",
-	on_use = minetest.item_eat(5, "cucina_vegana:bowl"),
+	on_use = core.item_eat(5, "cucina_vegana:bowl"),
 	paramtype = "light",
 	is_ground_content = false,
 	walkable = false,
@@ -548,7 +548,7 @@ minetest.register_node("cucina_vegana:salad_hollandaise", {
 	sounds = default.node_sound_glass_defaults(),
 })
 
-minetest.register_node("cucina_vegana:soy_soup", {
+core.register_node("cucina_vegana:soy_soup", {
 	description = S("Soy Soup (raw)"),
 	drawtype = "plantlike",
 	tiles = {"cucina_vegana_soy_soup.png"},
@@ -565,7 +565,7 @@ minetest.register_node("cucina_vegana:soy_soup", {
 	sounds = default.node_sound_glass_defaults(),
 })
 
-minetest.register_node("cucina_vegana:tofu_chives_rosemary", {
+core.register_node("cucina_vegana:tofu_chives_rosemary", {
 	description = S("Tofu on Chives and Rosemary (raw)"),
 	drawtype = "plantlike",
 	tiles = {"cucina_vegana_tofu_chives_rosemary.png"},
@@ -574,7 +574,7 @@ minetest.register_node("cucina_vegana:tofu_chives_rosemary", {
 	paramtype = "light",
 	is_ground_content = false,
 	walkable = false,
-	on_use = minetest.item_eat(5,  "cucina_vegana:plate"),
+	on_use = core.item_eat(5,  "cucina_vegana:plate"),
 	selection_box = {
 		type = "fixed",
 		fixed = {-0.25, -0.5, -0.25, 0.25, 0.3, 0.25}
@@ -587,7 +587,7 @@ minetest.register_node("cucina_vegana:tofu_chives_rosemary", {
 --   *****       Dinners cooked            *****
 --   *******************************************
 
-minetest.register_node("cucina_vegana:asparagus_hollandaise_cooked", {
+core.register_node("cucina_vegana:asparagus_hollandaise_cooked", {
 	description = S("Asparagus Hollandaise"),
 	drawtype = "plantlike",
 	tiles = {"cucina_vegana_asparagus_hollandaise_cooked.png"},
@@ -596,7 +596,7 @@ minetest.register_node("cucina_vegana:asparagus_hollandaise_cooked", {
 	paramtype = "light",
 	is_ground_content = false,
 	walkable = false,
-	on_use = minetest.item_eat(5,  "cucina_vegana:plate"),
+	on_use = core.item_eat(5,  "cucina_vegana:plate"),
 	selection_box = {
 		type = "fixed",
 		fixed = {-0.25, -0.5, -0.25, 0.25, 0.3, 0.25}
@@ -605,7 +605,7 @@ minetest.register_node("cucina_vegana:asparagus_hollandaise_cooked", {
 	sounds = default.node_sound_glass_defaults(),
 })
 
-minetest.register_node("cucina_vegana:asparagus_rice_cooked", {
+core.register_node("cucina_vegana:asparagus_rice_cooked", {
 	description = S("Asparagus on Rice"),
 	drawtype = "plantlike",
 	tiles = {"cucina_vegana_asparagus_rice_cooked.png"},
@@ -614,7 +614,7 @@ minetest.register_node("cucina_vegana:asparagus_rice_cooked", {
 	paramtype = "light",
 	is_ground_content = false,
 	walkable = false,
-	on_use = minetest.item_eat(6,  "cucina_vegana:plate"),
+	on_use = core.item_eat(6,  "cucina_vegana:plate"),
 	selection_box = {
 		type = "fixed",
 		fixed = {-0.25, -0.5, -0.25, 0.25, 0.3, 0.25}
@@ -623,7 +623,7 @@ minetest.register_node("cucina_vegana:asparagus_rice_cooked", {
 	sounds = default.node_sound_glass_defaults(),
 })
 
-minetest.register_node("cucina_vegana:asparagus_soup_cooked", {
+core.register_node("cucina_vegana:asparagus_soup_cooked", {
 	description = S("Asparagus Soup"),
 	drawtype = "plantlike",
 	tiles = {"cucina_vegana_asparagus_soup_cooked.png"},
@@ -632,7 +632,7 @@ minetest.register_node("cucina_vegana:asparagus_soup_cooked", {
 	paramtype = "light",
 	is_ground_content = false,
 	walkable = false,
-	on_use = minetest.item_eat(5,  "cucina_vegana:plate"),
+	on_use = core.item_eat(5,  "cucina_vegana:plate"),
 	selection_box = {
 		type = "fixed",
 		fixed = {-0.25, -0.5, -0.25, 0.25, 0.3, 0.25}
@@ -641,7 +641,7 @@ minetest.register_node("cucina_vegana:asparagus_soup_cooked", {
 	sounds = default.node_sound_glass_defaults(),
 })
 
-minetest.register_node("cucina_vegana:bowl_rice_cooked", {
+core.register_node("cucina_vegana:bowl_rice_cooked", {
 	description = S("Bowl of Rice"),
 	drawtype = "plantlike",
 	tiles = {"cucina_vegana_bowl_rice_cooked.png"},
@@ -649,7 +649,7 @@ minetest.register_node("cucina_vegana:bowl_rice_cooked", {
 	wield_image = "cucina_vegana_bowl_rice_cooked.png",
 	paramtype = "light",
 	is_ground_content = false,
-	on_use = minetest.item_eat(4,  "cucina_vegana:bowl"),
+	on_use = core.item_eat(4,  "cucina_vegana:bowl"),
 	walkable = false,
 	selection_box = {
 		type = "fixed",
@@ -659,7 +659,7 @@ minetest.register_node("cucina_vegana:bowl_rice_cooked", {
 	sounds = default.node_sound_glass_defaults(),
 })
 
-minetest.register_node("cucina_vegana:fish_parsley_rosemary_cooked", {
+core.register_node("cucina_vegana:fish_parsley_rosemary_cooked", {
 	description = S("Fish on Parsley and Rosemary"),
 	drawtype = "plantlike",
 	tiles = {"cucina_vegana_fish_parsley_rosemary_cooked.png"},
@@ -668,7 +668,7 @@ minetest.register_node("cucina_vegana:fish_parsley_rosemary_cooked", {
 	paramtype = "light",
 	is_ground_content = false,
 	walkable = false,
-	on_use = minetest.item_eat(6,  "cucina_vegana:plate"),
+	on_use = core.item_eat(6,  "cucina_vegana:plate"),
 	selection_box = {
 		type = "fixed",
 		fixed = {-0.25, -0.5, -0.25, 0.25, 0.3, 0.25}
@@ -677,7 +677,7 @@ minetest.register_node("cucina_vegana:fish_parsley_rosemary_cooked", {
 	sounds = default.node_sound_glass_defaults(),
 })
 
-minetest.register_node("cucina_vegana:kohlrabi_soup_cooked", {
+core.register_node("cucina_vegana:kohlrabi_soup_cooked", {
 	description = S("Kohlrabi Soup"),
 	drawtype = "plantlike",
 	tiles = {"cucina_vegana_kohlrabi_soup_cooked.png"},
@@ -686,7 +686,7 @@ minetest.register_node("cucina_vegana:kohlrabi_soup_cooked", {
 	paramtype = "light",
 	is_ground_content = false,
 	walkable = false,
-	on_use = minetest.item_eat(5,  "cucina_vegana:plate"),
+	on_use = core.item_eat(5,  "cucina_vegana:plate"),
 	selection_box = {
 		type = "fixed",
 		fixed = {-0.25, -0.5, -0.25, 0.25, 0.3, 0.25}
@@ -695,7 +695,7 @@ minetest.register_node("cucina_vegana:kohlrabi_soup_cooked", {
 	sounds = default.node_sound_glass_defaults(),
 })
 
-minetest.register_node("cucina_vegana:pizza_vegana_raw", {
+core.register_node("cucina_vegana:pizza_vegana_raw", {
 	description = S("Pizza Vegana (raw)"),
 	drawtype = "plantlike",
 	tiles = {"cucina_vegana_pizza_vegana_raw.png"},
@@ -711,7 +711,7 @@ minetest.register_node("cucina_vegana:pizza_vegana_raw", {
 	groups = {dig_immediate = 3, attached_node = 1, food_vegan = 1},
 })
 
-minetest.register_node("cucina_vegana:pizza_vegana", {
+core.register_node("cucina_vegana:pizza_vegana", {
 	description = S("Pizza Vegana"),
 	drawtype = "plantlike",
 	tiles = {"cucina_vegana_pizza_vegana.png"},
@@ -720,7 +720,7 @@ minetest.register_node("cucina_vegana:pizza_vegana", {
 	paramtype = "light",
 	is_ground_content = false,
 	walkable = false,
-	on_use = minetest.item_eat(6),
+	on_use = core.item_eat(6),
 	selection_box = {
 		type = "fixed",
 		fixed = {-0.25, -0.5, -0.25, 0.25, 0.3, 0.25}
@@ -728,7 +728,7 @@ minetest.register_node("cucina_vegana:pizza_vegana", {
 	groups = {dig_immediate = 3, attached_node = 1, food_vegan = 1, eatable = 1},
 })
 
-minetest.register_node("cucina_vegana:pizza_funghi_raw", {
+core.register_node("cucina_vegana:pizza_funghi_raw", {
 	description = S("Pizza Funghi (raw)"),
 	drawtype = "plantlike",
 	tiles = {"cucina_vegana_pizza_funghi_raw.png"},
@@ -744,7 +744,7 @@ minetest.register_node("cucina_vegana:pizza_funghi_raw", {
 	groups = {dig_immediate = 3, attached_node = 1, food_vegan = 1},
 })
 
-minetest.register_node("cucina_vegana:pizza_funghi", {
+core.register_node("cucina_vegana:pizza_funghi", {
 	description = S("Pizza Funghi"),
 	drawtype = "plantlike",
 	tiles = {"cucina_vegana_pizza_funghi.png"},
@@ -753,7 +753,7 @@ minetest.register_node("cucina_vegana:pizza_funghi", {
 	paramtype = "light",
 	is_ground_content = false,
 	walkable = false,
-	on_use = minetest.item_eat(6),
+	on_use = core.item_eat(6),
 	selection_box = {
 		type = "fixed",
 		fixed = {-0.25, -0.5, -0.25, 0.25, 0.3, 0.25}
@@ -761,7 +761,7 @@ minetest.register_node("cucina_vegana:pizza_funghi", {
 	groups = {dig_immediate = 3, attached_node = 1, food_vegan = 1, eatable = 1},
 })
 
-minetest.register_node("cucina_vegana:soy_soup_cooked", {
+core.register_node("cucina_vegana:soy_soup_cooked", {
 	description = S("Soy Soup"),
 	drawtype = "plantlike",
 	tiles = {"cucina_vegana_soy_soup_cooked.png"},
@@ -770,7 +770,7 @@ minetest.register_node("cucina_vegana:soy_soup_cooked", {
 	paramtype = "light",
 	is_ground_content = false,
 	walkable = false,
-	on_use = minetest.item_eat(5,  "cucina_vegana:plate"),
+	on_use = core.item_eat(5,  "cucina_vegana:plate"),
 	selection_box = {
 		type = "fixed",
 		fixed = {-0.25, -0.5, -0.25, 0.25, 0.3, 0.25}
@@ -779,7 +779,7 @@ minetest.register_node("cucina_vegana:soy_soup_cooked", {
 	sounds = default.node_sound_glass_defaults(),
 })
 
-minetest.register_node("cucina_vegana:tofu_chives_rosemary_cooked", {
+core.register_node("cucina_vegana:tofu_chives_rosemary_cooked", {
 	description = S("Tofu on Chives and Rosemary"),
 	drawtype = "plantlike",
 	tiles = {"cucina_vegana_tofu_chives_rosemary_cooked.png"},
@@ -788,7 +788,7 @@ minetest.register_node("cucina_vegana:tofu_chives_rosemary_cooked", {
 	paramtype = "light",
 	is_ground_content = false,
 	walkable = false,
-	on_use = minetest.item_eat(6,  "cucina_vegana:plate"),
+	on_use = core.item_eat(6,  "cucina_vegana:plate"),
 	selection_box = {
 		type = "fixed",
 		fixed = {-0.25, -0.5, -0.25, 0.25, 0.3, 0.25}

--- a/onion.lua
+++ b/onion.lua
@@ -23,7 +23,7 @@ farming.register_plant("cucina_vegana:" .. pname, {
 })
 
 -- Register for Mapgen
-minetest.register_node("cucina_vegana:wild_" .. pname, {
+core.register_node("cucina_vegana:wild_" .. pname, {
 	description = S("Wild") .. " " .. dname,
 	paramtype = "light",
 	walkable = false,
@@ -68,7 +68,7 @@ if(cucina_vegana.signs_bot) then
 
 end
 
-minetest.register_decoration({
+core.register_decoration({
 	deco_type = "simple",
 	place_on = {"default:dirt_with_grass"},
 	sidelen = 16,

--- a/overrides.lua
+++ b/overrides.lua
@@ -1,56 +1,56 @@
-local modname = minetest.get_current_modname()
+local modname = core.get_current_modname()
 
-if(minetest.registered_items["bees:bottle_honey"] ~= nil) then
+if(core.registered_items["bees:bottle_honey"] ~= nil) then
     cucina_vegana.add_group("bees:bottle_honey", {food = 1, food_honey = 1})
     print("[MOD] " .. modname .. " Group changed on \"bees:bottle_honey\".")
-    minetest.log("info", "[MOD] " .. modname .. " Group changed on \"bees:bottle_honey\".")
+    core.log("info", "[MOD] " .. modname .. " Group changed on \"bees:bottle_honey\".")
 
 end
 
-if(minetest.registered_items["farming:bread"] ~= nil) then
+if(core.registered_items["farming:bread"] ~= nil) then
     cucina_vegana.add_group("farming:bread",{food_bread = 1})
     print("[MOD] " .. modname .. " Group changed on \"farming:bread\".")
-    minetest.log("info", "[MOD] " .. modname .. " Group changed on \"farming:bread\".")
+    core.log("info", "[MOD] " .. modname .. " Group changed on \"farming:bread\".")
 
 end
 
-if(minetest.registered_items["farming:bread_slice"] ~= nil) then
+if(core.registered_items["farming:bread_slice"] ~= nil) then
     cucina_vegana.add_group("farming:bread_slice",{food_bread = 1})
     print("[MOD] " .. modname .. " Group changed on \"farming:bread_slice\".")
-    minetest.log("info", "[MOD] " .. modname .. " Group changed on \"farming:bread_slice\".")
+    core.log("info", "[MOD] " .. modname .. " Group changed on \"farming:bread_slice\".")
 
 end
 
-if(minetest.registered_items["farming:pumpkin_bread"] ~= nil) then
+if(core.registered_items["farming:pumpkin_bread"] ~= nil) then
     cucina_vegana.add_group("farming:pumpkin_bread", {food_bread = 1})
     print("[MOD] " .. modname .. " Group changed on \"farming:pumpkin_bread\".")
-    minetest.log("info", "[MOD] " .. modname .. " Group changed on \"farming:pumpkin_bread\".")
+    core.log("info", "[MOD] " .. modname .. " Group changed on \"farming:pumpkin_bread\".")
 end
 
-if(minetest.registered_items["farming_food:corn_bread"] ~= nil) then
+if(core.registered_items["farming_food:corn_bread"] ~= nil) then
     cucina_vegana.add_group("farming_food:corn_bread",{food_bread = 1})
     print("[MOD] " .. modname .. " Group changed on \"farming_food:corn_bread\".")
-    minetest.log("info", "[MOD] " .. modname .. " Group changed on \"farming_food:corn_bread\".")
+    core.log("info", "[MOD] " .. modname .. " Group changed on \"farming_food:corn_bread\".")
 
 end
 
-if(minetest.registered_items["farming:rice_bread"] ~= nil) then
+if(core.registered_items["farming:rice_bread"] ~= nil) then
     cucina_vegana.add_group("farming:rice_bread", {food = 1, food_bread = 1})
     print("[MOD] " .. modname .. " Group changed on \"farming:rice_bread\".")
-    minetest.log("info", "[MOD] " .. modname .. " Group changed on \"farming:rice_bread\".")
+    core.log("info", "[MOD] " .. modname .. " Group changed on \"farming:rice_bread\".")
 
 end
 
-if(minetest.registered_items["farming:rice"] ~= nil) then
+if(core.registered_items["farming:rice"] ~= nil) then
     cucina_vegana.add_group("farming:rice", {food = 1, food_rice = 1})
     print("[MOD] " .. modname .. " Group changed on \"farming:rice\".")
-    minetest.log("info", "[MOD] " .. modname .. " Group changed on \"farming:rice\".")
+    core.log("info", "[MOD] " .. modname .. " Group changed on \"farming:rice\".")
 
 end
 
-if(minetest.registered_items["farming:rice_flour"] ~= nil) then
+if(core.registered_items["farming:rice_flour"] ~= nil) then
     cucina_vegana.add_group("farming:rice_flour", {food = 1, food_flour = 1})
     print("[MOD] " .. modname .. " Group changed on \"farming:rice_flour\".")
-    minetest.log("info", "[MOD] " .. modname .. " Group changed on \"farming:rice_flour\".")
+    core.log("info", "[MOD] " .. modname .. " Group changed on \"farming:rice_flour\".")
 
 end

--- a/parsley.lua
+++ b/parsley.lua
@@ -23,7 +23,7 @@ farming.register_plant("cucina_vegana:" .. pname, {
 })
 
 -- Register for Mapgen
-minetest.register_node("cucina_vegana:wild_" .. pname, {
+core.register_node("cucina_vegana:wild_" .. pname, {
 	description = S("Wild") .. " " .. dname,
 	paramtype = "light",
 	walkable = false,
@@ -48,9 +48,9 @@ minetest.register_node("cucina_vegana:wild_" .. pname, {
 	},
 })
 
-minetest.register_alias("parsley:parsley", "cucina_vegana:" .. pname)
-minetest.register_alias("parsley:seed", "cucina_vegana:" .. pname .. "_seed")
-minetest.register_alias("parsley:wild_parsley", "cucina_vegana:wild_" .. pname)
+core.register_alias("parsley:parsley", "cucina_vegana:" .. pname)
+core.register_alias("parsley:seed", "cucina_vegana:" .. pname .. "_seed")
+core.register_alias("parsley:wild_parsley", "cucina_vegana:wild_" .. pname)
 
 if(cucina_vegana.plant_settings.bonemeal) then
     table.insert(cucina_vegana.plant_settings.bonemeal_list,
@@ -70,7 +70,7 @@ if(cucina_vegana.signs_bot) then
 
 end
 
-minetest.register_decoration({
+core.register_decoration({
 	deco_type = "simple",
 	place_on = {"default:dirt_with_grass", "default:dirt_with_dry_grass"},
 	sidelen = 16,

--- a/peanut.lua
+++ b/peanut.lua
@@ -23,7 +23,7 @@ farming.register_plant("cucina_vegana:" .. pname, {
 })
 
 -- Register for Mapgen
-minetest.register_node("cucina_vegana:wild_" .. pname, {
+core.register_node("cucina_vegana:wild_" .. pname, {
 	description = S("Wild") .. " " .. dname,
 	paramtype = "light",
 	walkable = false,
@@ -67,7 +67,7 @@ if(cucina_vegana.signs_bot) then
 
 end
 
-minetest.register_decoration({
+core.register_decoration({
 	deco_type = "simple",
 	place_on = {"default:dirt_with_grass", "default:dirt_with_dry_grass"},
 	sidelen = 16,

--- a/potato.lua
+++ b/potato.lua
@@ -23,7 +23,7 @@ farming.register_plant("cucina_vegana:" .. pname, {
 })
 
 -- Register for Mapgen
-minetest.register_node("cucina_vegana:wild_" .. pname, {
+core.register_node("cucina_vegana:wild_" .. pname, {
 	description = S("Wild") .. " " .. dname,
 	paramtype = "light",
 	walkable = false,
@@ -68,7 +68,7 @@ if(cucina_vegana.signs_bot) then
 
 end
 
-minetest.register_decoration({
+core.register_decoration({
 	deco_type = "simple",
 	place_on = {"default:dirt", "default:dirt_with_grass", "default:dry_dirt_with_dry_grass"},
 	sidelen = 16,

--- a/recipes.lua
+++ b/recipes.lua
@@ -6,7 +6,7 @@
 --   *****           Supports              *****
 --   *******************************************
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:blueberry_pot",
 	recipe = {	{"group:food_sugar", "default:stick", "group:food_sugar"},
 				{"cucina_vegana:blueberry_puree", "cucina_vegana:blueberry_puree", "cucina_vegana:blueberry_puree"},
@@ -17,7 +17,7 @@ minetest.register_craft({
                    }
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:blueberry_pot",
 	recipe = {	{"group:food_sugar", "default:stick", "group:food_sugar"},
 				{"cucina_vegana:blueberry_puree", "cucina_vegana:blueberry_puree", "cucina_vegana:blueberry_puree"},
@@ -28,7 +28,7 @@ minetest.register_craft({
                    }
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:blueberry_pot",
 	recipe = {	{"cucina_vegana:molasses", "default:stick", "cucina_vegana:molasses"},
 				{"cucina_vegana:blueberry_puree", "cucina_vegana:blueberry_puree", "cucina_vegana:blueberry_puree"},
@@ -40,7 +40,7 @@ minetest.register_craft({
                    }
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:blueberry_pot",
 	recipe = {	{"cucina_vegana:molasses", "default:stick", "cucina_vegana:molasses"},
 				{"cucina_vegana:blueberry_puree", "cucina_vegana:blueberry_puree", "cucina_vegana:blueberry_puree"},
@@ -52,14 +52,14 @@ minetest.register_craft({
                    }
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:bowl 5",
 	recipe = {	{"default:glass", "", "default:glass"},
 				{"default:glass", "default:glass", "default:glass"},
              }
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:bread_garlic",
 	recipe = {	{"group:food_flour", "cucina_vegana:sunflower_seeds_oil", ""},
 				{"cucina_vegana:rosemary", "cucina_vegana:garlic", ""}
@@ -68,7 +68,7 @@ minetest.register_craft({
                         {"cucina_vegana:sunflower_seeds_oil", "vessels:glass_bottle"},
                     }
 })
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:ciabatta_dough",
 	recipe = {	{"cucina_vegana:soy_milk", "cucina_vegana:sunflower_seeds_oil", ""},
 				{"group:food_flour", "cucina_vegana:rosemary", ""}
@@ -79,7 +79,7 @@ minetest.register_craft({
                     }
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:coffe_cup 4",
 	recipe = {	{"cucina_vegana:coffee_powder", "bucket:bucket_water", "default:paper"},
 				{"group:food_milk", "cucina_vegana:coffee_powder", ""}
@@ -90,7 +90,7 @@ minetest.register_craft({
                     }
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:coffee_cup 4",
 	recipe = {	{"cucina_vegana:coffee_powder", "bucket:bucket_river_water", "default:paper"},
 				{"group:food_milk", "cucina_vegana:coffee_powder", ""}
@@ -101,7 +101,7 @@ minetest.register_craft({
                     }
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:coffee_powder",
 	recipe = {	{"group:stone", "cucina_vegana:coffee_beans_roasted", "group:stone"},
 				{"group:stone", "cucina_vegana:coffee_beans_roasted", "group:stone"}
@@ -111,7 +111,7 @@ minetest.register_craft({
                     }
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:dandelion_suds",
 	recipe = {	{"flowers:dandelion_yellow", "flowers:dandelion_yellow", "flowers:dandelion_yellow"},
 				{"flowers:dandelion_yellow", "flowers:dandelion_yellow", "flowers:dandelion_yellow"},
@@ -119,7 +119,7 @@ minetest.register_craft({
 			}
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:dandelion_suds",
 	recipe = {	{"flowers:dandelion_yellow", "flowers:dandelion_yellow", "flowers:dandelion_yellow"},
 				{"flowers:dandelion_yellow", "flowers:dandelion_yellow", "flowers:dandelion_yellow"},
@@ -127,7 +127,7 @@ minetest.register_craft({
 			}
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:flax_seed_oil",
 	recipe = {	{"group:seed_flax", "group:seed_flax", "group:seed_flax"},
 				{"group:seed_flax", "group:seed_flax", "group:seed_flax"},
@@ -135,7 +135,7 @@ minetest.register_craft({
 			}
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:lettuce_oil",
 	recipe = {	{"group:seed_lettuce", "group:seed_lettuce", "group:seed_lettuce"},
 				{"group:seed_lettuce", "group:seed_lettuce", "group:seed_lettuce"},
@@ -143,7 +143,7 @@ minetest.register_craft({
 			}
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:peanut_oil",
 	recipe = {	{"group:seed_peanut", "group:seed_peanut", "group:seed_peanut"},
 				{"group:seed_peanut", "group:seed_peanut", "group:seed_peanut"},
@@ -151,7 +151,7 @@ minetest.register_craft({
 			}
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:corn_oil",
 	recipe = {	{"cucina_vegana:seed_corn", "cucina_vegana:seed_corn", "cucina_vegana:seed_corn"},
 				{"cucina_vegana:seed_corn", "cucina_vegana:seed_corn", "cucina_vegana:seed_corn"},
@@ -159,7 +159,7 @@ minetest.register_craft({
 			}
 })
 
-minetest.register_craft({
+core.register_craft({
         output = "cucina_vegana:mushroomlight_glass 4",
         recipe = {
                   {"","default:glass",""},
@@ -169,7 +169,7 @@ minetest.register_craft({
 })
 
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:pizza_dough",
 	recipe = {	{"group:food_milk", "group:food_oil", "group:food_cheese"},
 				{"group:food_flour", "group:food_flour", "group:food_flour"}
@@ -180,7 +180,7 @@ minetest.register_craft({
                     }
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:pizza_vegana_raw",
 	recipe = {	{"", "cucina_vegana:sauce_hollandaise", ""},
 				{"cucina_vegana:asparagus", "cucina_vegana:lettuce", "cucina_vegana:rosemary"},
@@ -192,7 +192,7 @@ minetest.register_craft({
 
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:pizza_funghi_raw",
 	recipe = {	{"", "group:food_oil", "cucina_vegana:rosemary"},
 				{"flowers:mushroom_brown", "cucina_vegana:imitation_meat", "flowers:mushroom_brown"},
@@ -204,42 +204,42 @@ minetest.register_craft({
 
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:plate 5",
 	recipe = {	{"group:wood", "", "group:wood"},
 				{"group:wood", "default:cobble", "group:wood"}
 			}
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:plate 2",
 	recipe = {	{"default:clay_lump", "", "default:clay_lump"},
 				{"default:clay_lump", "default:cobble", "default:clay_lump"}
 			}
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:plate 10",
 	recipe = {	{"default:steel_ingot", "", "default:steel_ingot"},
 				{"default:steel_ingot", "default:cobble", "default:steel_ingot"}
 			}
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:plate 10",
 	recipe = {	{"default:copper_ingot", "", "default:copper_ingot"},
 				{"default:copper_ingot", "default:cobble", "default:copper_ingot"}
 			}
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:plate 10",
 	recipe = {	{"default:tin_ingot", "", "default:tin_ingot"},
 				{"default:tin_ingot", "default:cobble", "default:tin_ingot"}
 			}
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:sunflower_seeds_flour",
 	recipe = {	{"default:stone", "default:stone", "default:stone"},
 				{"cucina_vegana:sunflower_seeds", "cucina_vegana:sunflower_seeds", "cucina_vegana:sunflower_seeds"},
@@ -252,7 +252,7 @@ minetest.register_craft({
 
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:sunflower_seeds_flour",
 	recipe = {	{"default:stone", "default:stone", "default:stone"},
 				{"cucina_vegana:sunflower_seeds", "cucina_vegana:sunflower_seeds", "cucina_vegana:sunflower_seeds"},
@@ -265,7 +265,7 @@ minetest.register_craft({
 
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:sunflower_seeds_flour",
 	recipe = {	{"default:desert_stone", "default:desert_stone", "default:desert_stone"},
 				{"cucina_vegana:sunflower_seeds", "cucina_vegana:sunflower_seeds", "cucina_vegana:sunflower_seeds"},
@@ -278,7 +278,7 @@ minetest.register_craft({
 
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:sunflower_seeds_flour",
 	recipe = {	{"default:desert_stone", "default:desert_stone", "default:desert_stone"},
 				{"cucina_vegana:sunflower_seeds", "cucina_vegana:sunflower_seeds", "cucina_vegana:sunflower_seeds"},
@@ -291,7 +291,7 @@ minetest.register_craft({
 
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:rice_flour",
 	recipe = {	{"default:stone", "default:stone", "default:stone"},
 				{"cucina_vegana:rice", "cucina_vegana:rice", "cucina_vegana:rice"},
@@ -304,7 +304,7 @@ minetest.register_craft({
 
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:rice_flour",
 	recipe = {	{"default:desert_stone", "default:desert_stone", "default:desert_stone"},
 				{"cucina_vegana:rice", "cucina_vegana:rice", "cucina_vegana:rice"},
@@ -317,7 +317,7 @@ minetest.register_craft({
 
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:rice_flour",
 	recipe = {	{"default:desert_stone", "default:desert_stone", "default:desert_stone"},
 				{"cucina_vegana:rice", "cucina_vegana:rice", "cucina_vegana:rice"},
@@ -330,7 +330,7 @@ minetest.register_craft({
 
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:rice_flour",
 	recipe = {	{"default:stone", "default:stone", "default:stone"},
 				{"cucina_vegana:rice", "cucina_vegana:rice", "cucina_vegana:rice"},
@@ -343,7 +343,7 @@ minetest.register_craft({
 
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:rice_starch 2",
 	recipe = {	{"wool:white", "cucina_vegana:rice", "wool:white"},
 				{"wool:white", "cucina_vegana:rice", "wool:white"},
@@ -356,7 +356,7 @@ minetest.register_craft({
 
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:rice_starch 2",
 	recipe = {	{"wool:white", "cucina_vegana:rice", "wool:white"},
 				{"wool:white", "cucina_vegana:rice", "wool:white"},
@@ -369,7 +369,7 @@ minetest.register_craft({
 
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "wool:white",
 	recipe = {	{"cucina_vegana:flax_roasted", "cucina_vegana:flax_roasted", "cucina_vegana:flax_roasted"},
 				{"cucina_vegana:flax_roasted", "cucina_vegana:flax_roasted", "cucina_vegana:flax_roasted"},
@@ -380,7 +380,7 @@ minetest.register_craft({
 --   *****           Imitations            *****
 --   *******************************************
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:imitation_butter",
 	recipe = {	{"group:dye,color_yellow", "cucina_vegana:soy_milk",  "cucina_vegana:soy_milk"}
 			},
@@ -389,13 +389,13 @@ minetest.register_craft({
 						}
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:imitation_cheese",
 	recipe = {	{"group:dye,color_orange","cucina_vegana:imitation_butter", "cucina_vegana:imitation_butter"}
 			},
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:imitation_fish",
 	recipe = {
 				{"group:dye,color_blue","cucina_vegana:tofu", "group:dye,color_blue"},
@@ -405,7 +405,7 @@ minetest.register_craft({
 			},
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:imitation_meat",
 	recipe = {	{"group:dye,color_red", "cucina_vegana:tofu", "group:dye,color_white"},
 				{"", "cucina_vegana:tofu", ""},
@@ -413,7 +413,7 @@ minetest.register_craft({
 			},
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:imitation_poultry",
 	recipe = {	{"cucina_vegana:tofu", "", "group:dye,color_yellow"},
 				{"", "cucina_vegana:tofu", ""},
@@ -421,7 +421,7 @@ minetest.register_craft({
 			},
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:soy_milk",
 	recipe = {
 			{"cucina_vegana:soy", "cucina_vegana:soy", "cucina_vegana:soy"},
@@ -430,7 +430,7 @@ minetest.register_craft({
 		},
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:tofu",
 	recipe = {
 			{"cucina_vegana:soy", "cucina_vegana:soy", "cucina_vegana:soy"},
@@ -443,7 +443,7 @@ minetest.register_craft({
 --   *****       Side Dishes               *****
 --   *******************************************
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:blueberry_jam",
 	recipe = {	{"cucina_vegana:blueberry_pot_cooked", "", ""},
                 {"group:wool", "", ""},
@@ -455,7 +455,7 @@ minetest.register_craft({
                    }
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:cucumber_in_glass",
 	recipe = {	{"cucina_vegana:cucumber", "cucina_vegana:cucumber", "cucina_vegana:cucumber"},
                 {"", "cucina_vegana:cucumber", ""},
@@ -463,7 +463,7 @@ minetest.register_craft({
 			},
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:bowl_rice",
 	recipe = {
 				{"cucina_vegana:rice"},
@@ -475,7 +475,7 @@ minetest.register_craft({
 						}
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:bowl_rice",
 	recipe = {
 				{"cucina_vegana:rice"},
@@ -487,7 +487,7 @@ minetest.register_craft({
 						}
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:dandelion_honey",
 	recipe = {	{"cucina_vegana:dandelion_suds_cooking", "", ""},
                 {"group:wool", "", ""},
@@ -499,7 +499,7 @@ minetest.register_craft({
                    }
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:edamame",
 	recipe = {	{"cucina_vegana:rosemary", "group:seed_soy", "cucina_vegana:peanut"},
                 {"group:seed_soy", "group:seed_soy", "group:seed_soy"},
@@ -507,7 +507,7 @@ minetest.register_craft({
 			}
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:sauce_hollandaise",
 	recipe = {	{"cucina_vegana:parsley", "group:food_butter", "cucina_vegana:rosemary"},
 				{"", "cucina_vegana:soy_milk", ""},
@@ -518,7 +518,7 @@ minetest.register_craft({
                    }
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:sunflower_seeds_oil",
 	recipe = {	{"cucina_vegana:sunflower_seeds", "cucina_vegana:sunflower_seeds", "cucina_vegana:sunflower_seeds"},
 				{"cucina_vegana:sunflower_seeds", "cucina_vegana:sunflower_seeds", "cucina_vegana:sunflower_seeds"},
@@ -526,7 +526,7 @@ minetest.register_craft({
 			}
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:molasses",
 	recipe = {
 				{"", "default:stick", ""},
@@ -539,7 +539,7 @@ minetest.register_craft({
 						}
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:molasses",
 	recipe = {
 				{"", "default:stick", ""},
@@ -552,7 +552,7 @@ minetest.register_craft({
 						}
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:peanut_butter",
 	recipe = {
 				{"cucina_vegana:peanut", "default:stick", "cucina_vegana:peanut"},
@@ -564,7 +564,7 @@ minetest.register_craft({
 						}
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:vegan_strawberry_milk",
 	recipe = {
 				{"cucina_vegana:strawberry", "default:stick", "cucina_vegana:strawberry"},
@@ -576,7 +576,7 @@ minetest.register_craft({
 						}
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:vegan_strawberry_milk",
 	recipe = {
 				{"group:food_strawberry", "default:stick", "group:food_strawberry"},
@@ -591,7 +591,7 @@ minetest.register_craft({
 --   *****           Dinners               *****
 --   *******************************************
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:asparagus_hollandaise",
 	recipe = {	{"cucina_vegana:asparagus", "cucina_vegana:sauce_hollandaise", "cucina_vegana:parsley"},
 				{"", "group:food_plate", ""}
@@ -600,7 +600,7 @@ minetest.register_craft({
 						}
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:asparagus_rice",
 	recipe = {
 				{"cucina_vegana:asparagus", "group:food_rice", "group:food_butter"},
@@ -611,7 +611,7 @@ minetest.register_craft({
 						}
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:asparagus_soup",
 	recipe = {	{"cucina_vegana:chives", "group:food_oil", "cucina_vegana:asparagus"},
 				{"", "cucina_vegana:soy_milk", ""},
@@ -622,7 +622,7 @@ minetest.register_craft({
 						}
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:fish_parsley_rosemary",
 	recipe = {
 				{"cucina_vegana:parsley","group:food_oil", "cucina_vegana:rosemary"},
@@ -634,7 +634,7 @@ minetest.register_craft({
 						}
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:fryer_raw",
 	recipe = {
 				{"default:paper","", "default:paper"},
@@ -646,7 +646,7 @@ minetest.register_craft({
 						}
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:fryer_raw",
 	recipe = {
 				{"default:paper","", "default:paper"},
@@ -655,7 +655,7 @@ minetest.register_craft({
 			},
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:kohlrabi_soup",
 	recipe = {	{"cucina_vegana:kohlrabi", "group:food_oil", "cucina_vegana:parsley"},
 				{"", "bucket:bucket_water", ""},
@@ -666,7 +666,7 @@ minetest.register_craft({
 						}
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:kohlrabi_soup",
 	recipe = {	{"cucina_vegana:kohlrabi", "group:food_oil", "cucina_vegana:parsley"},
 				{"", "bucket:bucket_river_water", ""},
@@ -677,7 +677,7 @@ minetest.register_craft({
 						}
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:salad_bowl",
 	recipe = {	{"cucina_vegana:parsley", "cucina_vegana:lettuce", "cucina_vegana:chives"},
 				{"", "group:food_oil", ""},
@@ -688,7 +688,7 @@ minetest.register_craft({
                            }
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:salad_hollandaise",
 	recipe = {
 				{"cucina_vegana:sauce_hollandaise", "cucina_vegana:salad_bowl", ""}
@@ -698,7 +698,7 @@ minetest.register_craft({
                            }
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:salad_hollandaise",
 	recipe = {	{"cucina_vegana:parsley", "cucina_vegana:lettuce", "cucina_vegana:chives"},
 				{"cucina_vegana:sauce_hollandaise", "group:food_oil", ""},
@@ -711,7 +711,7 @@ minetest.register_craft({
 
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:sea_salad",
 	recipe = {	{"default:jungleleaves", "cucina_vegana:parsley", "cucina_vegana:lettuce"},
 				{"cucina_vegana:chives", "bucket:bucket_water", "cucina_vegana:asparagus"},
@@ -723,7 +723,7 @@ minetest.register_craft({
 
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:soy_soup",
 	recipe = {	{"cucina_vegana:chives", "group:food_oil", "cucina_vegana:parsley"},
 				{"", "cucina_vegana:soy_milk", ""},
@@ -734,7 +734,7 @@ minetest.register_craft({
 						}
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:tofu_chives_rosemary",
 	recipe = {	{"cucina_vegana:chives", "", "cucina_vegana:rosemary"},
 				{"", "cucina_vegana:tofu", ""},
@@ -742,7 +742,7 @@ minetest.register_craft({
 			},
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:vegan_sushi",
 	recipe = {	{"cucina_vegana:imitation_fish", "cucina_vegana:bowl_rice", ""},
 				{"default:papyrus", "", ""}
@@ -756,7 +756,7 @@ minetest.register_craft({
 --   *****          Miscelanous            *****
 --   *******************************************
 
-minetest.register_craft({
+core.register_craft({
 	type = "shapeless",
 	output = "cucina_vegana:sunflower_seeds 4",
 	recipe = {"flowers:sunflower"},
@@ -765,14 +765,14 @@ minetest.register_craft({
 	}
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:sunflower_seeds_dough",
 	recipe = {	{"", "cucina_vegana:sunflower_seeds", ""},
 				{"farming:flour", "farming:flour", "farming:flour"}
 			}
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "cucina_vegana:sunflower_seeds_dough",
 	recipe = {	{"", "cucina_vegana:sunflower_seeds", ""},
 				{"group:food_flour", "group:food_flour", "group:food_flour"}
@@ -780,7 +780,7 @@ minetest.register_craft({
 })
 
 
-minetest.register_craft({
+core.register_craft({
 	output = "default:paper 4",
 	recipe = {	{"default:stone", "cucina_vegana:flax_roasted", "default:stone"},
 				{"default:stone", "cucina_vegana:flax_roasted", "default:stone"},
@@ -792,7 +792,7 @@ minetest.register_craft({
                     }
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "default:paper 4",
 	recipe = {	{"default:desert_stone", "cucina_vegana:flax_roasted", "default:desert_stone"},
 				{"default:desert_stone", "cucina_vegana:flax_roasted", "default:desert_stone"},
@@ -804,7 +804,7 @@ minetest.register_craft({
                     }
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "default:paper 4",
 	recipe = {	{"default:cobble", "cucina_vegana:flax_roasted", "default:cobble"},
 				{"default:cobble", "cucina_vegana:flax_roasted", "default:cobble"},
@@ -816,7 +816,7 @@ minetest.register_craft({
                     }
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "default:paper 4",
 	recipe = {	{"default:desert_cobble", "cucina_vegana:flax_roasted", "default:desert_cobble"},
 				{"default:desert_cobble", "cucina_vegana:flax_roasted", "default:desert_cobble"},
@@ -828,7 +828,7 @@ minetest.register_craft({
                     }
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "default:paper 4",
 	recipe = {	{"default:stone", "cucina_vegana:flax_roasted", "default:stone"},
 				{"default:stone", "cucina_vegana:flax_roasted", "default:stone"},
@@ -840,7 +840,7 @@ minetest.register_craft({
                     }
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "default:paper 4",
 	recipe = {	{"default:desert_stone", "cucina_vegana:flax_roasted", "default:desert_stone"},
 				{"default:desert_stone", "cucina_vegana:flax_roasted", "default:desert_stone"},
@@ -852,7 +852,7 @@ minetest.register_craft({
                     }
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "default:paper 4",
 	recipe = {	{"default:cobble", "cucina_vegana:flax_roasted", "default:cobble"},
 				{"default:cobble", "cucina_vegana:flax_roasted", "default:cobble"},
@@ -864,7 +864,7 @@ minetest.register_craft({
                     }
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "default:paper 4",
 	recipe = {	{"default:desert_cobble", "cucina_vegana:flax_roasted", "default:desert_cobble"},
 				{"default:desert_cobble", "cucina_vegana:flax_roasted", "default:desert_cobble"},
@@ -876,7 +876,7 @@ minetest.register_craft({
                     }
 })
 
-minetest.register_craft({
+core.register_craft({
 	output = "farming:cotton 2",
 	recipe = {
               {"cucina_vegana:flax_roasted","default:stick","cucina_vegana:flax_roasted"},
@@ -886,7 +886,7 @@ minetest.register_craft({
                 },
 })
 
-minetest.register_craft({
+core.register_craft({
 	type = "shapeless",
 	output = "cucina_vegana:seed_corn 10",
 	recipe = {"cucina_vegana:corn"},

--- a/recipes_5xx.lua
+++ b/recipes_5xx.lua
@@ -2,81 +2,74 @@
 --   **       Support for 5.0                 **
 --   *******************************************
 
-local modname = minetest.get_current_modname()
+local modname = core.get_current_modname()
 
 local nodes = {
-                {
-                    name = "default:sand_with_kelp",                                                    -- Name
-                    output = "cucina_vegana:vegan_sushi", 	                                            -- Output
-                    recipe = {	                                                                        -- Recipe
-                                {"cucina_vegana:imitation_fish", "cucina_vegana:bowl_rice", ""},
-                                {"default:sand_with_kelp", "", ""}
-                            },
-            --repclaements = nil                                                                       -- Replacements
+    {
+        name = "default:sand_with_kelp",
+        output = "cucina_vegana:vegan_sushi",
+        recipe = {
+            {"cucina_vegana:imitation_fish", "cucina_vegana:bowl_rice", ""},
+            {"default:sand_with_kelp", "", ""}
+        },
+            -- repclaements = nil
             -- replacements = {{"cucina_vegana:molasses", "vessels:drinking_glass"}}
-                },
-                {
-                    name = "flowers:waterlily",                                                         -- Name
-                    output = "cucina_vegana:sea_salad",
-                    recipe = {
-                            {"flowers:waterlily","cucina_vegana:parsley", "cucina_vegana:lettuce"},
-                            {"cucina_vegana:chives","bucket:bucket_water", "cucina_vegana:asparagus"},
-                            {"","cucina_vegana:bowl", ""},
-                        },
-                    replacements = {
-                            {"bucket:bucket_water", "bucket:bucket_empty"},
-                        },
-                },
+    },
+    {
+        name = "flowers:waterlily",
+        output = "cucina_vegana:sea_salad",
+        recipe = {
+            {"flowers:waterlily", "cucina_vegana:parsley", "cucina_vegana:lettuce"},
+            {"cucina_vegana:chives", "bucket:bucket_water", "cucina_vegana:asparagus"},
+            {"", "cucina_vegana:bowl", ""},
+        },
+        replacements = {
+            {"bucket:bucket_water", "bucket:bucket_empty"},
+        },
+    },
 
-            --repclaements = nil                                                                       -- Replacements
-            -- replacements = {{"cucina_vegana:molasses", "vessels:drinking_glass"}}
-                }
-
+    -- repclaements = nil
+    -- replacements = {{"cucina_vegana:molasses", "vessels:drinking_glass"}}
+}
 
 for node, value in ipairs(nodes) do
-    --print("[MT 5.x.x] Found " .. value.name .. " to register.")
-    if(minetest.registered_nodes[value.name] or minetest.registered_items[value.name]) then
-        minetest.register_craft({
-                                    output = value.output,
-                                    recipe = value.recipe,
-                                    replacements = value.replacements
-                                })
+    if(core.registered_nodes[value.name] or core.registered_items[value.name]) then
+        core.register_craft({
+            output = value.output,
+            recipe = value.recipe,
+            replacements = value.replacements
+        })
 
-        minetest.log("info", "[MOD] " .. modname .. " Added a 5.x.x-Recipe with " .. value.name .. "\".")
-        --print("[MT 5.x.x] " .. value.output .. " Recipe with " .. value.name .. " registered.")
-
-    end -- if(minetest.registered_nodes
-
-end -- for node
+        core.log("info", "[MOD] " .. modname .. " Added a 5.x.x-Recipe with " .. value.name .. "\".")
+    end
+end
 
 local berries = {
-                    "default:blueberries",
-                    "farming:blueberries",
-                    "bushes:blueberry"
-                }
+    "default:blueberries",
+    "farming:blueberries",
+    "bushes:blueberry"
+}
 
 local press = {
-                    "default:stone",
-                    "default:cobble",
-                    "default:desert_stone",
-                    "default:desert_cobble"
+    "default:stone",
+    "default:cobble",
+    "default:desert_stone",
+    "default:desert_cobble"
+}
+
+for bkey, berry in ipairs(berries) do
+    for mkey, mat in ipairs(press) do
+        core.log("info", "[MOD] " .. modname .. " Registering Berry: " .. berry .. " with " .. mat .. ".")
+        core.register_craft({
+            output = "cucina_vegana:blueberry_puree",
+            recipe = {
+                {mat, berry, berry},
+                {mat, berry, berry},
+                {mat, berry, berry},
+            },
+            replacements = {
+                {mat, mat .. " 3"}
             }
-
-for bkey,berry in ipairs(berries) do
-    for mkey,mat in ipairs(press) do
-        minetest.log("info", "[MOD] " .. modname .. " Registering Berry: " .. berry .. " with " .. mat .. ".")
-        minetest.register_craft({
-                            output = "cucina_vegana:blueberry_puree",
-                            recipe = {
-                                        {mat, berry, berry},
-                                        {mat, berry, berry},
-                                        {mat, berry, berry},
-                                    },
-                            replacements = {
-                                                {mat, mat .. " 3"}
-                                            }
-        }) -- minetest.register_craft
-
-    end -- for mkey, mat
-
-end -- for bkey, berry
+        })
+    end
+end

--- a/recipes_cook.lua
+++ b/recipes_cook.lua
@@ -2,91 +2,91 @@
 --   *****                 Cookings        *****
 --   *******************************************
 
-minetest.register_craft({
+core.register_craft({
 	type = "cooking",
 	cooktime = 18,
 	output = "cucina_vegana:asparagus_hollandaise_cooked",
 	recipe = "cucina_vegana:asparagus_hollandaise"
 })
 
-minetest.register_craft({
+core.register_craft({
 	type = "cooking",
 	cooktime = 10,
 	output = "cucina_vegana:asparagus_rice_cooked",
 	recipe = "cucina_vegana:asparagus_rice"
 })
 
-minetest.register_craft({
+core.register_craft({
 	type = "cooking",
 	cooktime = 15,
 	output = "cucina_vegana:asparagus_soup_cooked",
 	recipe = "cucina_vegana:asparagus_soup"
 })
 
-minetest.register_craft({
+core.register_craft({
 	type = "cooking",
 	cooktime = 25,
 	output = "cucina_vegana:blueberry_pot_cooked",
 	recipe = "cucina_vegana:blueberry_pot"
 })
 
-minetest.register_craft({
+core.register_craft({
 	type = "cooking",
 	cooktime = 20,
 	output = "cucina_vegana:bowl_rice_cooked",
 	recipe = "cucina_vegana:bowl_rice"
 })
 
-minetest.register_craft({
+core.register_craft({
 	type = "cooking",
 	cooktime = 13,
 	output = "cucina_vegana:bread_garlic_cooked",
 	recipe = "cucina_vegana:bread_garlic"
 })
 
-minetest.register_craft({
+core.register_craft({
 	type = "cooking",
 	cooktime = 17,
 	output = "cucina_vegana:ciabatta_bread",
 	recipe = "cucina_vegana:ciabatta_dough"
 })
 
-minetest.register_craft({
+core.register_craft({
 	type = "cooking",
 	cooktime = 20,
 	output = "cucina_vegana:dandelion_suds_cooking",
 	recipe = "cucina_vegana:dandelion_suds"
 })
 
-minetest.register_craft({
+core.register_craft({
 	type = "cooking",
 	cooktime = 7,
 	output = "cucina_vegana:edamame_cooked",
 	recipe = "cucina_vegana:edamame"
 })
 
-minetest.register_craft({
+core.register_craft({
 	type = "cooking",
 	cooktime = 25,
 	output = "cucina_vegana:fryer",
 	recipe = "cucina_vegana:fryer_raw"
 })
 
-minetest.register_craft({
+core.register_craft({
 	type = "cooking",
 	cooktime = 18,
 	output = "cucina_vegana:fish_parsley_rosemary_cooked",
 	recipe = "cucina_vegana:fish_parsley_rosemary"
 })
 
-minetest.register_craft({
+core.register_craft({
 	type = "cooking",
 	cooktime = 20,
 	output = "cucina_vegana:kohlrabi_roasted",
 	recipe = "cucina_vegana:kohlrabi"
 })
 
-minetest.register_craft({
+core.register_craft({
 	type = "cooking",
 	cooktime = 15,
 	output = "cucina_vegana:kohlrabi_soup_cooked",
@@ -94,35 +94,35 @@ minetest.register_craft({
 })
 
 
-minetest.register_craft({
+core.register_craft({
 	type = "cooking",
 	output = "cucina_vegana:peanut",
 	recipe = "group:seed_peanut",
 	cooktime = 5,
 })
 
-minetest.register_craft({
+core.register_craft({
 	type = "cooking",
 	cooktime = 18,
 	output = "cucina_vegana:pizza_vegana",
 	recipe = "cucina_vegana:pizza_vegana_raw"
 })
 
-minetest.register_craft({
+core.register_craft({
 	type = "cooking",
 	cooktime = 18,
 	output = "cucina_vegana:pizza_funghi",
 	recipe = "cucina_vegana:pizza_funghi_raw"
 })
 
-minetest.register_craft({
+core.register_craft({
 	type = "cooking",
 	cooktime = 15,
 	output = "cucina_vegana:soy_soup_cooked",
 	recipe = "cucina_vegana:soy_soup"
 })
 
-minetest.register_craft({
+core.register_craft({
 	type = "cooking",
 	cooktime = 14,
 	output = "bushes:sugar",
@@ -130,55 +130,55 @@ minetest.register_craft({
     replacements = {{"cucina_vegana:molasses", "vessels:drinking_glass"}}
 })
 
-minetest.register_craft({
+core.register_craft({
 	type = "cooking",
 	cooktime = 15,
 	output = "cucina_vegana:sunflower_seeds_bread",
 	recipe = "cucina_vegana:sunflower_seeds_dough"
 })
 
-minetest.register_craft({
+core.register_craft({
 	type = "cooking",
 	output = "cucina_vegana:sunflower_seeds_roasted",
 	recipe = "cucina_vegana:sunflower_seeds"
 })
 
-minetest.register_craft({
+core.register_craft({
 	type = "cooking",
 	cooktime = 18,
 	output = "cucina_vegana:tofu_chives_rosemary_cooked",
 	recipe = "cucina_vegana:tofu_chives_rosemary"
 })
 
-minetest.register_craft({
+core.register_craft({
 	type = "cooking",
 	output = "cucina_vegana:tofu_cooked",
 	recipe = "cucina_vegana:tofu",
 	cooktime = 5,
 })
 
-minetest.register_craft({
+core.register_craft({
 	type = "cooking",
 	output = "cucina_vegana:flax_roasted",
 	recipe = "cucina_vegana:flax",
 	cooktime = 10,
 })
 
-minetest.register_craft({
+core.register_craft({
 	type = "cooking",
 	output = "cucina_vegana:popcorn",
 	recipe = "cucina_vegana:corn",
 	cooktime = 8,
 })
 
-minetest.register_craft({
+core.register_craft({
 	type = "cooking",
 	output = "cucina_vegana:coffee_beans_roasted",
 	recipe = "cucina_vegana:coffee_beans_raw",
 	cooktime = 8,
 })
 
-minetest.register_craft({
+core.register_craft({
 	type = "cooking",
 	output = "cucina_vegana:coffee_cup_hot",
 	recipe = "cucina_vegana:coffee_cup",

--- a/recipes_support.lua
+++ b/recipes_support.lua
@@ -2,7 +2,7 @@
 --   **             Recipe differences        **
 --   *******************************************
 
-local modname = minetest.get_current_modname()
+local modname = core.get_current_modname()
 
 --   *******************************************
 --   ** Additional Recipes with other Mods  **
@@ -14,16 +14,16 @@ local modname = minetest.get_current_modname()
         **************************************************
 ]]--
 
-if minetest.get_modpath("mobs") then
+if core.get_modpath("mobs") then
 
-	minetest.register_craft({
+	core.register_craft({
 		output = "mobs:meat_raw",
 		recipe = {
 			{"cucina_vegana:tofu", "cucina_vegana:tofu", "cucina_vegana:tofu"}
 		}
 	})
 
-	minetest.register_craft({
+	core.register_craft({
 		output = "mobs:chicken_raw",
 		recipe = {
 			{"", "", "cucina_vegana:tofu"},
@@ -32,9 +32,9 @@ if minetest.get_modpath("mobs") then
 		}
 	})
 
-    minetest.log("info", "[MOD] " .. modname .. ": mobs supported.")
+    core.log("info", "[MOD] " .. modname .. ": mobs supported.")
 
-end -- if minetest.get_modpath("mobs"
+end -- if core.get_modpath("mobs"
 
 --[[
         **************************************************
@@ -42,9 +42,9 @@ end -- if minetest.get_modpath("mobs"
         **************************************************
 ]]--
 
-if minetest.get_modpath("animalmaterials") then
+if core.get_modpath("animalmaterials") then
 
-	minetest.register_craft({
+	core.register_craft({
 		output = "animalmaterials:milk",
 		recipe = {
 			{"cucina_vegana:milk", "cucina_vegana:milk", "cucina_vegana:milk"},
@@ -53,9 +53,9 @@ if minetest.get_modpath("animalmaterials") then
 		replacements = {{"cucina_vegana:milk", "vessels:drinking_glass"}}
 	})
 
-    minetest.log("info", "[MOD] " .. modname .. ": animalmaterials supported.")
+    core.log("info", "[MOD] " .. modname .. ": animalmaterials supported.")
 
-end -- if minetest.get_modpath("animalmaterials"
+end -- if core.get_modpath("animalmaterials"
 
 --[[
         **************************************************
@@ -63,7 +63,7 @@ end -- if minetest.get_modpath("animalmaterials"
         **************************************************
 ]]--
 
-if minetest.get_modpath("fishing") then
+if core.get_modpath("fishing") then
 
     cucina_vegana.add_group("fishing:fish_raw", {food_fish = 1})
     cucina_vegana.add_group("fishing:clownfish_raw", {food_fish = 1})
@@ -73,14 +73,14 @@ if minetest.get_modpath("fishing") then
     cucina_vegana.add_group("fishing:perch_raw", {food_fish = 1})
     cucina_vegana.add_group("fishing:catfish_raw", {food_fish = 1})
 
-	minetest.register_craft({
+	core.register_craft({
 		type = "shapeless",
 		output = "fishing:sushi",
 		recipe = {"group:food_fish","group:food_rice","flowers:seaweed"},
 		replacements = {{"group:food_rice", "cucina_vegana:bowl"}}
 	})
 
-	minetest.register_craft({
+	core.register_craft({
 		type = "shapeless",
 		output = "fishing:sushi",
 		recipe = {"group:food_fish","group:food_rice","seaplants:kelpgreen"},
@@ -88,7 +88,7 @@ if minetest.get_modpath("fishing") then
 
 	})
 
-	minetest.register_craft({
+	core.register_craft({
 		type = "shapeless",
 		output = "fishing:sushi",
 		recipe = {"group:food_fish","group:food_rice","seaplants:kelpgreen"},
@@ -96,7 +96,7 @@ if minetest.get_modpath("fishing") then
 
 	})
 
-    minetest.register_craft({
+    core.register_craft({
 		type = "shapeless",
 		output = "fishing:sushi",
 		recipe = {"group:food_fish","group:food_rice","default:jungleleaves"},
@@ -104,9 +104,9 @@ if minetest.get_modpath("fishing") then
 
 	})
 
-    minetest.log("info", "[MOD] " .. modname .. ": fishing supported.")
+    core.log("info", "[MOD] " .. modname .. ": fishing supported.")
 
-end -- if minetest.get_modpath("fishing"
+end -- if core.get_modpath("fishing"
 
 --[[
         **************************************************
@@ -114,47 +114,47 @@ end -- if minetest.get_modpath("fishing"
         **************************************************
 ]]--
 
-if minetest.get_modpath("bbq") then
+if core.get_modpath("bbq") then
 
 	-- *** group:food_meat
 
 	--BBQ Beef Ribs Craft Recipe
-	minetest.register_craft( {
+	core.register_craft( {
 		output = "bbq:bbq_beef_ribs_raw 2",
 		type = "shapeless",
 		recipe = {"bbq:bbq_sauce", "group:food_meat", "group:food_pepper_ground"}
 	})
 
 	--Corned Beef Craft Recipe
-	minetest.register_craft( {
+	core.register_craft( {
 		output = "bbq:corned_beef_raw",
 		type = "shapeless",
 		recipe = {"group:food_peppercorn", "group:food_meat","bbq:brine",}
 	})
 
 	--BBQ Brisket Craft Recipe
-	minetest.register_craft( {
+	core.register_craft( {
 		output = "bbq:brisket_raw 2",
 		type = "shapeless",
 		recipe = {"bbq:bbq_sauce", "bbq:molasses", "group:food_meat", "group:food_garlic_clove"}
 	})
 
 	--London Broil Craft Recipe
-	minetest.register_craft( {
+	core.register_craft( {
 		output = "bbq:london_broil_raw 2",
 		type = "shapeless",
 		recipe = {"bbq:bacon", "group:food_garlic_clove", "group:food_meat"}
 	})
 
 	--Beef Jerky Craft Recipe
-	minetest.register_craft( {
+	core.register_craft( {
 		output = "bbq:beef_jerky_raw 3",
 		type = "shapeless",
 		recipe = {"bbq:liquid_smoke", "bbq:brine", "group:food_meat"}
 	})
 
 	--Pepper Steak Craft Recipe
-	minetest.register_craft( {
+	core.register_craft( {
 		output = "bbq:pepper_steak_raw",
 		type = "shapeless",
 		recipe = {"group:food_pepper_ground", "group:food_meat", "group:food_pepper_ground"}
@@ -163,49 +163,49 @@ if minetest.get_modpath("bbq") then
 	-- *** group:food_bread
 
 	--Cheese Steak Craft Recipe
-	minetest.register_craft( {
+	core.register_craft( {
 		output = "bbq:cheese_steak 2",
 		type = "shapeless",
 		recipe = {"group:food_bread", "group:food_pepper", "bbq:beef", "group:food_cheese", "group:food_onion"}
 	})
 
 	--Bacon Cheeseburger Craft Recipe
-	minetest.register_craft( {
+	core.register_craft( {
 		output = "bbq:bacon_cheeseburger 3",
 		type = "shapeless",
 		recipe = {"group:food_bread", "bbq:bacon", "bbq:hamburger_patty", "group:food_cheese"}
 	})
 
 	--Bacon Cheeseburger Craft Recipe
-	minetest.register_craft( {
+	core.register_craft( {
 		output = "bbq:bacon_cheeseburger 3",
 		type = "shapeless",
 		recipe = {"group:food_bread", "bbq:bacon", "group:food_meat", "group:food_cheese"}
 	})
 
 	--Hamburger Craft Recipe
-	minetest.register_craft( {
+	core.register_craft( {
         output = "bbq:hamburger 2",
 		type = "shapeless",
 		recipe = {"group:food_bread", "bbq:hamburger_patty"}
 	})
 
 	--Hamburger Craft Recipe
-	minetest.register_craft( {
+	core.register_craft( {
 		output = "bbq:hamburger 2",
 		type = "shapeless",
 		recipe = {"group:food_bread", "group:food_meat"}
 	})
 
 	--Hotdog Craft Recipe
-	minetest.register_craft( {
+	core.register_craft( {
 		output = "bbq:hotdog 2",
 		type = "shapeless",
 		recipe = {"bbq:hotdog_cooked", "group:food_bread"}
 	})
 
 	--Pulled Pork Craft Recipe
-	minetest.register_craft( {
+	core.register_craft( {
 		output = "bbq:pulled_pork 2",
 		type = "shapeless",
 		recipe = {"mobs:pork_cooked", "group:food_bread", "bbq:bbq_sauce"}
@@ -213,28 +213,28 @@ if minetest.get_modpath("bbq") then
 
 
 	--Stuffed Chop Craft Recipe
-	minetest.register_craft( {
+	core.register_craft( {
 		output = "bbq:stuffed_chop_raw 3",
 		type = "shapeless",
 		recipe = {"group:food_onion", "group:food_bread", "flowers:mushroom_brown", "mobs:pork_raw", "default:apple"}
 	})
 
 	--Stuffed Mushroom Craft Recipe
-	minetest.register_craft( {
+	core.register_craft( {
 		output = "bbq:stuffed_mushroom_raw 2",
 		type = "shapeless",
 		recipe = {"group:food_tomato", "group:food_bread", "flowers:mushroom_brown"}
 	})
 
 	--Stuffed Pepper Craft Recipe
-	minetest.register_craft( {
+	core.register_craft( {
 		output = "bbq:stuffed_pepper_raw 3",
 		type = "shapeless",
 		recipe = {"group:food_cheese", "group:food_bread", "group:food_pepper"}
 	})
 
     -- bbq:bacon_raw
-	minetest.register_craft( {
+	core.register_craft( {
 		output = "bbq:bacon_raw 3",
 		recipe = {
 			{"bbq:basting_brush", "group:dye,color_red", "group:dye,color_white"},
@@ -243,7 +243,7 @@ if minetest.get_modpath("bbq") then
         replacements = {{"bbq:basting_brush", "bbq:basting_brush"}}
     })
 
-	minetest.register_craft( {
+	core.register_craft( {
 		output = "bbq:bbq_chicken_raw",
 		recipe = {
 			{"bbq:basting_brush", "bbq:hot_sauce", "cucina_vegana:tofu"},
@@ -253,7 +253,7 @@ if minetest.get_modpath("bbq") then
         replacements = {{"bbq:basting_brush", "bbq:basting_brush"}}
     })
 
-	minetest.register_craft( {
+	core.register_craft( {
 		output = "bbq:beef_raw",
 		recipe = {
 			{"bbq:basting_brush", "group:dye,color_red", "bbq:sea_salt"},
@@ -262,14 +262,14 @@ if minetest.get_modpath("bbq") then
         replacements = {{"bbq:basting_brush", "bbq:basting_brush"}}
     })
 
-	minetest.register_craft( {
+	core.register_craft( {
 		output = "bbq:ham_raw",
 		recipe = {
 			{"cucina_vegana:tofu", "bbq:liquid_smoke", "cucina_vegana:tofu"},
 		}
     })
 
-	minetest.register_craft( {
+	core.register_craft( {
 		output = "bbq:hot_wings_raw 2",
 		recipe = {
 			{"cucina_vegana:tofu", "", "cucina_vegana:tofu"},
@@ -278,7 +278,7 @@ if minetest.get_modpath("bbq") then
         }
     })
 
-	minetest.register_craft( {
+	core.register_craft( {
 		output = "bbq:hotdog_raw 3",
 		recipe = {
 			{"bbq:basting_brush", "group:food_salt", ""},
@@ -288,7 +288,7 @@ if minetest.get_modpath("bbq") then
         replacements = {{"bbq:basting_brush", "bbq:basting_brush"}}
     })
 
-    minetest.register_craft( {
+    core.register_craft( {
     output = "bbq:leg_lamb_raw",
     recipe = {
 			{"bbq:basting_brush", "cucina_vegana:imitation_butter", "cucina_vegana:soy_milk"},
@@ -298,7 +298,7 @@ if minetest.get_modpath("bbq") then
         replacements = {{"bbq:basting_brush", "bbq:basting_brush"}}
     })
 
-    minetest.register_craft( {
+    core.register_craft( {
         output = "bbq:rack_lamb_raw",
         recipe = {
 			{"bbq:basting_brush", "", "default:stick"},
@@ -310,7 +310,7 @@ if minetest.get_modpath("bbq") then
                         }
     })
 
-    minetest.register_craft( {
+    core.register_craft( {
         output = "bbq:lamb_kebab_raw",
         recipe = {
 			{"bbq:leg_lamb_raw", "default:stick", ""},
@@ -318,9 +318,9 @@ if minetest.get_modpath("bbq") then
         },
     })
 
-    minetest.log("info", "[MOD] " .. modname .. ": bbq supported.")
+    core.log("info", "[MOD] " .. modname .. ": bbq supported.")
 
-end -- if minetest.get_modpath("bbq"
+end -- if core.get_modpath("bbq"
 
 --[[
         **************************************************
@@ -328,8 +328,8 @@ end -- if minetest.get_modpath("bbq"
         **************************************************
 ]]--
 
-if minetest.get_modpath("pizza") then
-    minetest.register_craft({
+if core.get_modpath("pizza") then
+    core.register_craft({
         type = "shapeless",
         output = "pizza:pizza_dough",
         recipe = {"group:food_flour", "group:food_cheese", "group:food_tomato"},
@@ -337,13 +337,13 @@ if minetest.get_modpath("pizza") then
 
     cucina_vegana.add_group("pizza:pizza_dough", {pizza_dough = 1})
 
-    minetest.register_craft({
+    core.register_craft({
         type = "shapeless",
         output = "pizza:pizza_dough",
         recipe = {"cucina_vegana:pizza_dough"}
                             })
 
-    minetest.register_craft({
+    core.register_craft({
         type = "shapeless",
         output = "cucina_vegana:pizza_dough",
         recipe = {"pizza:pizza_dough"}
@@ -357,9 +357,9 @@ end
         **************************************************
 ]]--
 
-if minetest.get_modpath("homedecor") then
+if core.get_modpath("homedecor") then
 
-    minetest.register_craft( {
+    core.register_craft( {
         output = "homedecor:cobweb_corner 5",
         recipe = {
 			{ "cucina_vegana:flax_roasted", "", "cucina_vegana:flax_roasted" },
@@ -368,7 +368,7 @@ if minetest.get_modpath("homedecor") then
         },
     })
 
-    minetest.register_craft({
+    core.register_craft({
         output = "homedecor:oil_lamp",
         recipe = {
             { "", "vessels:glass_bottle", "" },
@@ -377,7 +377,7 @@ if minetest.get_modpath("homedecor") then
         }
     })
 
-    minetest.register_craft({
+    core.register_craft({
         output = "homedecor:oil_lamp_tabletop",
         recipe = {
             { "", "vessels:glass_bottle", "" },
@@ -386,7 +386,7 @@ if minetest.get_modpath("homedecor") then
         }
     })
 
-    minetest.register_craft({
+    core.register_craft({
         output = "homedecor:candle_thin 4",
         recipe = {
             {"cucina_vegana:flax_roasted" },
@@ -394,7 +394,7 @@ if minetest.get_modpath("homedecor") then
         }
     })
 
-    minetest.register_craft({
+    core.register_craft({
         output = "homedecor:candle 2",
         recipe = {
             {"cucina_vegana:flax_roasted" },
@@ -403,7 +403,7 @@ if minetest.get_modpath("homedecor") then
         }
     })
 
-    minetest.register_craft({
+    core.register_craft({
         output = "homedecor:blinds_thin",
         recipe = {
             { "group:stick", "basic_materials:plastic_sheet", "group:stick" },
@@ -412,7 +412,7 @@ if minetest.get_modpath("homedecor") then
         },
     })
 
-    minetest.register_craft({
+    core.register_craft({
         output = "homedecor:blinds_thick",
         recipe = {
             { "group:stick", "basic_materials:plastic_sheet", "group:stick" },
@@ -429,8 +429,8 @@ end
         **************************************************
 ]]--
 
-if minetest.get_modpath("building_blocks") then
-    minetest.register_craft({
+if core.get_modpath("building_blocks") then
+    core.register_craft({
         output = 'building_blocks:terrycloth_towel 2',
         recipe = {
             {"cucina_vegana:flax_roasted", "cucina_vegana:flax_roasted", "cucina_vegana:flax_roasted"},
@@ -445,8 +445,8 @@ end
         **************************************************
 ]]--
 
-if minetest.get_modpath("ropes") then
-	minetest.register_craft({
+if core.get_modpath("ropes") then
+	core.register_craft({
 		output = 'ropes:ropesegment',
 		recipe = {
 			{'cucina_vegana:flax_roasted','cucina_vegana:flax_roasted'},
@@ -455,7 +455,7 @@ if minetest.get_modpath("ropes") then
 		}
 	})
 
-	minetest.register_craft({
+	core.register_craft({
 		output = 'ropes:rope',
 		recipe = {
 			{'cucina_vegana:flax_roasted'},
@@ -471,8 +471,8 @@ end
         **************************************************
 ]]--
 
-if minetest.get_modpath("cottages") then
-    minetest.register_craft({
+if core.get_modpath("cottages") then
+    core.register_craft({
         output = "cottages:rope",
         recipe = {
             {"cucina_vegana:flax_roasted","",""},
@@ -489,8 +489,8 @@ end
         **************************************************
 ]]--
 
-if minetest.get_modpath("moreblocks") then
-    minetest.register_craft({
+if core.get_modpath("moreblocks") then
+    core.register_craft({
         output = "moreblocks:rope 3",
         recipe = {
             {"cucina_vegana:flax_roasted"},
@@ -507,9 +507,9 @@ end
         **************************************************
 ]]--
 
-if minetest.get_modpath("petz") then
+if core.get_modpath("petz") then
 
-    minetest.register_craft({
+    core.register_craft({
 	output = "petz:lasso",
 	recipe = {
 		{"cucina_vegana:flax_roasted", "", "cucina_vegana:flax_roasted"},
@@ -518,7 +518,7 @@ if minetest.get_modpath("petz") then
             }
     })
 
-    minetest.register_craft({
+    core.register_craft({
         type = "shaped",
         output = 'petz:pet_bowl',
         recipe = {
@@ -527,19 +527,19 @@ if minetest.get_modpath("petz") then
         }
     })
 
-    minetest.register_craft({
+    core.register_craft({
         type = "shapeless",
         output = "petz:blueberry_cheese_cake",
         recipe = {"group:food_blueberries", "farming:wheat", "group:food_cheese", "group:food_egg"},
     })
 
-    minetest.register_craft({
+    core.register_craft({
         type = "shapeless",
         output = "petz:blueberry_cheese_cake",
         recipe = {"group:food_blueberry", "farming:wheat", "group:food_cheese", "group:food_egg"},
     })
 
-    minetest.register_craft({
+    core.register_craft({
         type = "shapeless",
         output = "petz:blueberry_ice_cream 3",
         recipe = {"group:food_blueberries", "group:food_milk", "group:food_egg",
@@ -547,7 +547,7 @@ if minetest.get_modpath("petz") then
         replacements = {{"group:food_milk", "bucket:bucket_empty"}},
     })
 
-    minetest.register_craft({
+    core.register_craft({
         type = "shapeless",
         output = "petz:blueberry_ice_cream 3",
         recipe = {"group:food_blueberry", "group:food_milk", "group:food_egg",
@@ -555,7 +555,7 @@ if minetest.get_modpath("petz") then
         replacements = {{"group:food_milk", "bucket:bucket_empty"}},
     })
 
-    minetest.register_craft({
+    core.register_craft({
         type = "shapeless",
         output = "petz:blueberry_muffin 8",
         recipe = {"group:food_blueberries", "farming:wheat", "farming:wheat", "petz:chicken_egg",
@@ -563,7 +563,7 @@ if minetest.get_modpath("petz") then
         replacements = {{"group:food_milk", "bucket:bucket_empty"}},
     })
 
-    minetest.register_craft({
+    core.register_craft({
         type = "shapeless",
         output = "petz:blueberry_muffin 8",
         recipe = {"group:food_blueberry", "farming:wheat", "farming:wheat",
@@ -572,7 +572,7 @@ if minetest.get_modpath("petz") then
     })
 
     -- Dreamcatcher
-    minetest.register_craft({
+    core.register_craft({
         type = "shaped",
         output = "petz:dreamcatcher",
         recipe = {
@@ -582,7 +582,7 @@ if minetest.get_modpath("petz") then
                 }
     })
 
-    minetest.register_craft({
+    core.register_craft({
         type = "shaped",
         output = "petz:ducky_feather",
         recipe = {
@@ -596,7 +596,7 @@ if minetest.get_modpath("petz") then
     cucina_vegana.add_group("petz:milk", {food_milk = 1, eatable = 1})
     cucina_vegana.add_group("petz:honey_bottle", {food_sugar = 1, food_honey = 1})
 
-end -- if minetest.get_modpath("petz"
+end -- if core.get_modpath("petz"
 
 --[[
         **************************************************
@@ -604,9 +604,9 @@ end -- if minetest.get_modpath("petz"
         **************************************************
 ]]--
 
-if minetest.get_modpath("aqua_farming") then
+if core.get_modpath("aqua_farming") then
 
-    minetest.register_craft({
+    core.register_craft({
         output = "cucina_vegana:vegan_sushi",
         recipe = {	{"cucina_vegana:imitation_fish", "cucina_vegana:bowl_rice", ""},
                     {"aqua_farming:alga_item", "", ""}
@@ -616,7 +616,7 @@ if minetest.get_modpath("aqua_farming") then
         }
     })
 
-    minetest.register_craft({
+    core.register_craft({
         output = "cucina_vegana:imitation_fish",
         recipe = {
                     {"aqua_farming:sea_grass_item","cucina_vegana:tofu", "group:dye,color_blue"},
@@ -626,7 +626,7 @@ if minetest.get_modpath("aqua_farming") then
                 },
     })
 
-    minetest.register_craft({
+    core.register_craft({
         output = "cucina_vegana:sea_salad",
         recipe = {
                     {"aqua_farming:sea_cucumber_item","cucina_vegana:parsley", "cucina_vegana:lettuce"},

--- a/register_mods.lua
+++ b/register_mods.lua
@@ -85,7 +85,7 @@
 --   *****           Technic-Support       *****
 --   *******************************************
 
-if(minetest.get_modpath("technic")) then
+if(core.get_modpath("technic")) then
 
 
 	-- Support Compressor
@@ -178,13 +178,13 @@ if(minetest.get_modpath("technic")) then
 
     end
 
-end -- if(minetest.get_modpath("technic"
+end -- if(core.get_modpath("technic"
 
 --   *******************************************
 --   *****           Hunger-Support        *****
 --   *******************************************
 
-if(minetest.get_modpath("hunger")) then
+if(core.get_modpath("hunger")) then
     for key, item in pairs(cv_items) do
         hunger.register_food(item)
 
@@ -196,7 +196,7 @@ end -- hunger
 --   *****           Hunger_ng-Support        *****
 --   **********************************************
 
-if(minetest.get_modpath("hunger_ng")) then
+if(core.get_modpath("hunger_ng")) then
     local add = hunger_ng.add_hunger_data
 
     for key, item in pairs(cv_items) do
@@ -210,7 +210,7 @@ end -- hunger_ng
 --   *****           Wine-Support          *****
 --   *******************************************
 
-if(minetest.get_modpath("wine")) then
+if(core.get_modpath("wine")) then
     wine:add_item({ {"cucina_vegana:molasses", "wine:glass_rum"},
                     {"cucina_vegana:dandelion_honey", "wine:glass_mead"},
                     {"cucina_vegana:rice", "wine:glass_sake"},
@@ -223,10 +223,10 @@ end -- wine
 --   *****           Diet-Support          *****
 --   *******************************************
 
-if(minetest.get_modpath("diet")) then
+if(core.get_modpath("diet")) then
 
     local function overwrite(name, hunger_change, replace_with_item, poisen, heal)
-        local tab = minetest.registered_items[name]
+        local tab = core.registered_items[name]
         if not tab then
             return
         end
@@ -238,13 +238,13 @@ if(minetest.get_modpath("diet")) then
 
     end -- for key,item
 
-end -- if(minetest.get_modpath("diet
+end -- if(core.get_modpath("diet
 
 --   *******************************************
 --   *****           Petz-Support          *****
 --   *******************************************
 
-if(minetest.get_modpath("petz")) then
+if(core.get_modpath("petz")) then
     cucina_vegana.add_group("petz:bucket_milk", {food_milk = 1})
     cucina_vegana.add_group("petz:chicken_egg", {food = 2, food_egg = 1})
     cucina_vegana.add_group("petz:ducky_egg",{food = 2, food_egg = 1})
@@ -255,7 +255,7 @@ end
 --   *****      Lemontree-Support          *****
 --   *******************************************
 
-if(minetest.get_modpath("lemontree")) then
+if(core.get_modpath("lemontree")) then
     cucina_vegana.add_group("lemontree:lemon", {food_lemon = 1, food_fruit = 1})
 
 end
@@ -264,7 +264,7 @@ end
 --   *****      Clementinetree-Support          *****
 --   *******************************************
 
-if(minetest.get_modpath("clementinetree")) then
+if(core.get_modpath("clementinetree")) then
     cucina_vegana.add_group("clementinetree:clementine", {food_orange = 1, food_fruit = 1})
 
 end
@@ -272,8 +272,8 @@ end
 --   *******************************************
 --   *****      Techage-Support          *****
 --   *******************************************
-if(minetest.get_modpath("techage") and techage.register_plant) then
-	for name,ndef in pairs(minetest.registered_nodes) do
+if(core.get_modpath("techage") and techage.register_plant) then
+	for name,ndef in pairs(core.registered_nodes) do
 		if type(name) == "string" then
 			local mod = string.split(name, ":")[1]
 			if mod == "cucina_vegana" then

--- a/rice.lua
+++ b/rice.lua
@@ -23,7 +23,7 @@ farming.register_plant("cucina_vegana:" .. pname .. "", {
 })
 
 -- Register for Mapgen
-minetest.register_node("cucina_vegana:wild_" .. pname, {
+core.register_node("cucina_vegana:wild_" .. pname, {
 	description = S("Wild") .. " " .. dname,
 	paramtype = "light",
 	walkable = false,
@@ -66,7 +66,7 @@ if(cucina_vegana.signs_bot) then
 
 end
 
-minetest.register_decoration({
+core.register_decoration({
 	deco_type = "simple",
 	place_on = {"default:dirt_with_rainforest_litter", "default:dirt", "default:dirt_with_grass"},
 	spawn_by = {"default:water_source", "default:river_water_source",

--- a/rosemary.lua
+++ b/rosemary.lua
@@ -23,7 +23,7 @@ farming.register_plant("cucina_vegana:" .. pname, {
 })
 
 -- Register for Mapgen
-minetest.register_node("cucina_vegana:wild_" .. pname, {
+core.register_node("cucina_vegana:wild_" .. pname, {
 	description = S("Wild") .. " " .. dname,
 	paramtype = "light",
 	walkable = false,
@@ -66,7 +66,7 @@ if(cucina_vegana.signs_bot) then
 
 end
 
-minetest.register_decoration({
+core.register_decoration({
 	deco_type = "simple",
 	place_on = {"default:dirt_with_dry_grass", "default:sand", "default:silver_sand"},
 	sidelen = 16,

--- a/settings.lua
+++ b/settings.lua
@@ -15,9 +15,9 @@ local cv_setting = "cucina_vegana.settings."
 --  ***               general settings                   ***
 --  ********************************************************
 
-cucina_vegana.settings.coffee_effect_duration = minetest.settings:get(cv_setting .. "coffee_effect_duration") or 10
-cucina_vegana.settings.coffee_effect_speed = minetest.settings:get(cv_setting .. "coffee_effect_speed") or 3
-cucina_vegana.plant_settings.germ_launch = minetest.settings:get(cv_setting_plant .. "germ_launch") or 0 -- Start germ at:
+cucina_vegana.settings.coffee_effect_duration = core.settings:get(cv_setting .. "coffee_effect_duration") or 10
+cucina_vegana.settings.coffee_effect_speed = core.settings:get(cv_setting .. "coffee_effect_speed") or 3
+cucina_vegana.plant_settings.germ_launch = core.settings:get(cv_setting_plant .. "germ_launch") or 0 -- Start germ at:
 
 
 --  ********************************************************
@@ -25,123 +25,123 @@ cucina_vegana.plant_settings.germ_launch = minetest.settings:get(cv_setting_plan
 --  ********************************************************
 
 -- Asparagus
-cucina_vegana.plant_settings.asparagus = minetest.settings:get_bool(cv_setting_plant .. "asparagus", true)
-cucina_vegana.plant_settings.asparagus_scale = minetest.settings:get(cv_setting_plant .."asparagus_scale") or 0.0007
-cucina_vegana.plant_settings.asparagus_light = minetest.settings:get(cv_setting_plant .."asparagus_light") or 11
+cucina_vegana.plant_settings.asparagus = core.settings:get_bool(cv_setting_plant .. "asparagus", true)
+cucina_vegana.plant_settings.asparagus_scale = core.settings:get(cv_setting_plant .."asparagus_scale") or 0.0007
+cucina_vegana.plant_settings.asparagus_light = core.settings:get(cv_setting_plant .."asparagus_light") or 11
 
 -- Banana
-cucina_vegana.plant_settings.banana = minetest.settings:get_bool(cv_setting_plant .. "banana", true)
-cucina_vegana.plant_settings.banana_scale = minetest.settings:get(cv_setting_plant .."banana_scale") or 0.009
-cucina_vegana.plant_settings.banana_light = minetest.settings:get(cv_setting_plant .."banana") or 12
+cucina_vegana.plant_settings.banana = core.settings:get_bool(cv_setting_plant .. "banana", true)
+cucina_vegana.plant_settings.banana_scale = core.settings:get(cv_setting_plant .."banana_scale") or 0.009
+cucina_vegana.plant_settings.banana_light = core.settings:get(cv_setting_plant .."banana") or 12
 
 -- Carrot
-cucina_vegana.plant_settings.carrot = minetest.settings:get_bool(cv_setting_plant .."carrot", true)
-cucina_vegana.plant_settings.carrot_scale = minetest.settings:get(cv_setting_plant .."carrot_scale") or 0.0005
-cucina_vegana.plant_settings.carrot_light = minetest.settings:get(cv_setting_plant .."carrot_light") or 11
+cucina_vegana.plant_settings.carrot = core.settings:get_bool(cv_setting_plant .."carrot", true)
+cucina_vegana.plant_settings.carrot_scale = core.settings:get(cv_setting_plant .."carrot_scale") or 0.0005
+cucina_vegana.plant_settings.carrot_light = core.settings:get(cv_setting_plant .."carrot_light") or 11
 
 -- Chili
-cucina_vegana.plant_settings.chili = minetest.settings:get_bool(cv_setting_plant .."chili", true)
-cucina_vegana.plant_settings.chili_scale = minetest.settings:get(cv_setting_plant .."chili_scale") or 0.0002
-cucina_vegana.plant_settings.chili_light = minetest.settings:get(cv_setting_plant .."chili_light") or 13
+cucina_vegana.plant_settings.chili = core.settings:get_bool(cv_setting_plant .."chili", true)
+cucina_vegana.plant_settings.chili_scale = core.settings:get(cv_setting_plant .."chili_scale") or 0.0002
+cucina_vegana.plant_settings.chili_light = core.settings:get(cv_setting_plant .."chili_light") or 13
 
 -- Chives
-cucina_vegana.plant_settings.chives = minetest.settings:get_bool(cv_setting_plant .."chives", true)
-cucina_vegana.plant_settings.chives_scale = minetest.settings:get(cv_setting_plant .."chives_scale") or 0.0005
-cucina_vegana.plant_settings.chives_light = minetest.settings:get(cv_setting_plant .."chives_light") or 10
+cucina_vegana.plant_settings.chives = core.settings:get_bool(cv_setting_plant .."chives", true)
+cucina_vegana.plant_settings.chives_scale = core.settings:get(cv_setting_plant .."chives_scale") or 0.0005
+cucina_vegana.plant_settings.chives_light = core.settings:get(cv_setting_plant .."chives_light") or 10
 
 -- Corn
-cucina_vegana.plant_settings.corn = minetest.settings:get_bool(cv_setting_plant .."corn", true)
-cucina_vegana.plant_settings.corn_scale = minetest.settings:get(cv_setting_plant .."corn_scale") or 0.0004
-cucina_vegana.plant_settings.corn_light = minetest.settings:get(cv_setting_plant .."corn_light") or 13
+cucina_vegana.plant_settings.corn = core.settings:get_bool(cv_setting_plant .."corn", true)
+cucina_vegana.plant_settings.corn_scale = core.settings:get(cv_setting_plant .."corn_scale") or 0.0004
+cucina_vegana.plant_settings.corn_light = core.settings:get(cv_setting_plant .."corn_light") or 13
 
 -- Flax
-cucina_vegana.plant_settings.flax = minetest.settings:get_bool(cv_setting_plant .."flax", true)
-cucina_vegana.plant_settings.flax_scale = minetest.settings:get(cv_setting_plant .."flax_scale") or 0.0006
-cucina_vegana.plant_settings.flax_light = minetest.settings:get(cv_setting_plant .."flax_light") or 10
+cucina_vegana.plant_settings.flax = core.settings:get_bool(cv_setting_plant .."flax", true)
+cucina_vegana.plant_settings.flax_scale = core.settings:get(cv_setting_plant .."flax_scale") or 0.0006
+cucina_vegana.plant_settings.flax_light = core.settings:get(cv_setting_plant .."flax_light") or 10
 
 -- Kohlrabi
-cucina_vegana.plant_settings.kohlrabi = minetest.settings:get_bool(cv_setting_plant .."kohlrabi", true)
-cucina_vegana.plant_settings.kohlrabi_scale = minetest.settings:get(cv_setting_plant .."kohlrabi_scale") or 0.0007
-cucina_vegana.plant_settings.kohlrabi_light = minetest.settings:get(cv_setting_plant .."kohlrabi_light") or 13
+cucina_vegana.plant_settings.kohlrabi = core.settings:get_bool(cv_setting_plant .."kohlrabi", true)
+cucina_vegana.plant_settings.kohlrabi_scale = core.settings:get(cv_setting_plant .."kohlrabi_scale") or 0.0007
+cucina_vegana.plant_settings.kohlrabi_light = core.settings:get(cv_setting_plant .."kohlrabi_light") or 13
 
 -- Lettuce
-cucina_vegana.plant_settings.lettuce = minetest.settings:get_bool(cv_setting_plant .."lettuce", true)
-cucina_vegana.plant_settings.lettuce_scale = minetest.settings:get(cv_setting_plant .."lettuce_scale") or 0.0008
-cucina_vegana.plant_settings.lettuce_light = minetest.settings:get(cv_setting_plant .."lettuce_light") or 12
+cucina_vegana.plant_settings.lettuce = core.settings:get_bool(cv_setting_plant .."lettuce", true)
+cucina_vegana.plant_settings.lettuce_scale = core.settings:get(cv_setting_plant .."lettuce_scale") or 0.0008
+cucina_vegana.plant_settings.lettuce_light = core.settings:get(cv_setting_plant .."lettuce_light") or 12
 
 -- Parsley
-cucina_vegana.plant_settings.parsley = minetest.settings:get_bool(cv_setting_plant .."parsley", true)
-cucina_vegana.plant_settings.parsley_scale = minetest.settings:get(cv_setting_plant .."parsley_scale") or 0.0005
-cucina_vegana.plant_settings.parsley_light = minetest.settings:get(cv_setting_plant .."parsley_light") or 11
+cucina_vegana.plant_settings.parsley = core.settings:get_bool(cv_setting_plant .."parsley", true)
+cucina_vegana.plant_settings.parsley_scale = core.settings:get(cv_setting_plant .."parsley_scale") or 0.0005
+cucina_vegana.plant_settings.parsley_light = core.settings:get(cv_setting_plant .."parsley_light") or 11
 
 -- Peanut
-cucina_vegana.plant_settings.peanut = minetest.settings:get_bool(cv_setting_plant .."peanut", true)
-cucina_vegana.plant_settings.peanut_scale = minetest.settings:get(cv_setting_plant .."peanut_scale") or 0.0006
-cucina_vegana.plant_settings.peanut_light = minetest.settings:get(cv_setting_plant .."peanut_light") or 12
+cucina_vegana.plant_settings.peanut = core.settings:get_bool(cv_setting_plant .."peanut", true)
+cucina_vegana.plant_settings.peanut_scale = core.settings:get(cv_setting_plant .."peanut_scale") or 0.0006
+cucina_vegana.plant_settings.peanut_light = core.settings:get(cv_setting_plant .."peanut_light") or 12
 
 -- Rice
-cucina_vegana.plant_settings.rice = minetest.settings:get_bool(cv_setting_plant .."rice", true)
-cucina_vegana.plant_settings.rice_scale = minetest.settings:get(cv_setting_plant .."rice_scale") or 0.0005
-cucina_vegana.plant_settings.rice_light = minetest.settings:get(cv_setting_plant .."rice_light") or 12
+cucina_vegana.plant_settings.rice = core.settings:get_bool(cv_setting_plant .."rice", true)
+cucina_vegana.plant_settings.rice_scale = core.settings:get(cv_setting_plant .."rice_scale") or 0.0005
+cucina_vegana.plant_settings.rice_light = core.settings:get(cv_setting_plant .."rice_light") or 12
 
 -- Rosemary
-cucina_vegana.plant_settings.rosemary = minetest.settings:get_bool(cv_setting_plant .."rosemary", true)
-cucina_vegana.plant_settings.rosemary_scale = minetest.settings:get(cv_setting_plant .."rosemary") or 0.0008
-cucina_vegana.plant_settings.rosemary_light = minetest.settings:get(cv_setting_plant .."rosemary") or 12
+cucina_vegana.plant_settings.rosemary = core.settings:get_bool(cv_setting_plant .."rosemary", true)
+cucina_vegana.plant_settings.rosemary_scale = core.settings:get(cv_setting_plant .."rosemary") or 0.0008
+cucina_vegana.plant_settings.rosemary_light = core.settings:get(cv_setting_plant .."rosemary") or 12
 
 -- Soy
-cucina_vegana.plant_settings.soy = minetest.settings:get_bool(cv_setting_plant .."soy", true)
-cucina_vegana.plant_settings.soy_scale = minetest.settings:get(cv_setting_plant .."soy") or 0.0007
-cucina_vegana.plant_settings.soy_light = minetest.settings:get(cv_setting_plant .."soy") or 12
+cucina_vegana.plant_settings.soy = core.settings:get_bool(cv_setting_plant .."soy", true)
+cucina_vegana.plant_settings.soy_scale = core.settings:get(cv_setting_plant .."soy") or 0.0007
+cucina_vegana.plant_settings.soy_light = core.settings:get(cv_setting_plant .."soy") or 12
 
 -- Sunflowers
-cucina_vegana.plant_settings.sunflower = minetest.settings:get_bool(cv_setting_plant .."sunflower", true)
-cucina_vegana.plant_settings.sunflower_scale = minetest.settings:get(cv_setting_plant .."sunflower") or 0.0007
-cucina_vegana.plant_settings.sunflower_light = minetest.settings:get(cv_setting_plant .."sunflower") or 13
+cucina_vegana.plant_settings.sunflower = core.settings:get_bool(cv_setting_plant .."sunflower", true)
+cucina_vegana.plant_settings.sunflower_scale = core.settings:get(cv_setting_plant .."sunflower") or 0.0007
+cucina_vegana.plant_settings.sunflower_light = core.settings:get(cv_setting_plant .."sunflower") or 13
 
 -- Tomato
-cucina_vegana.plant_settings.tomato = minetest.settings:get_bool(cv_setting_plant .."tomato", true)
-cucina_vegana.plant_settings.tomato_scale = minetest.settings:get(cv_setting_plant .."tomato_scale") or 0.0006
-cucina_vegana.plant_settings.tomato_light = minetest.settings:get(cv_setting_plant .."tomato_light") or 11
+cucina_vegana.plant_settings.tomato = core.settings:get_bool(cv_setting_plant .."tomato", true)
+cucina_vegana.plant_settings.tomato_scale = core.settings:get(cv_setting_plant .."tomato_scale") or 0.0006
+cucina_vegana.plant_settings.tomato_light = core.settings:get(cv_setting_plant .."tomato_light") or 11
 
 -- Potato
-cucina_vegana.plant_settings.potato = minetest.settings:get_bool(cv_setting_plant .."potato", true)
-cucina_vegana.plant_settings.potato_scale = minetest.settings:get(cv_setting_plant .."potato_scale") or 0.0005
-cucina_vegana.plant_settings.potato_light = minetest.settings:get(cv_setting_plant .."potato_light") or 11
+cucina_vegana.plant_settings.potato = core.settings:get_bool(cv_setting_plant .."potato", true)
+cucina_vegana.plant_settings.potato_scale = core.settings:get(cv_setting_plant .."potato_scale") or 0.0005
+cucina_vegana.plant_settings.potato_light = core.settings:get(cv_setting_plant .."potato_light") or 11
 
 -- Garlic
-cucina_vegana.plant_settings.garlic = minetest.settings:get_bool(cv_setting_plant .."garlic", true)
-cucina_vegana.plant_settings.garlic_scale = minetest.settings:get(cv_setting_plant .."garlic_scale") or 0.0006
-cucina_vegana.plant_settings.garlic_light = minetest.settings:get(cv_setting_plant .."garlic_light") or 12
+cucina_vegana.plant_settings.garlic = core.settings:get_bool(cv_setting_plant .."garlic", true)
+cucina_vegana.plant_settings.garlic_scale = core.settings:get(cv_setting_plant .."garlic_scale") or 0.0006
+cucina_vegana.plant_settings.garlic_light = core.settings:get(cv_setting_plant .."garlic_light") or 12
 
 -- Onion
-cucina_vegana.plant_settings.onion = minetest.settings:get_bool(cv_setting_plant .."onion", true)
-cucina_vegana.plant_settings.onion_scale = minetest.settings:get(cv_setting_plant .."onion_scale") or 0.0006
-cucina_vegana.plant_settings.onion_light = minetest.settings:get(cv_setting_plant .."onion_light") or 12
+cucina_vegana.plant_settings.onion = core.settings:get_bool(cv_setting_plant .."onion", true)
+cucina_vegana.plant_settings.onion_scale = core.settings:get(cv_setting_plant .."onion_scale") or 0.0006
+cucina_vegana.plant_settings.onion_light = core.settings:get(cv_setting_plant .."onion_light") or 12
 
 -- Cucumber
-cucina_vegana.plant_settings.cucumber = minetest.settings:get_bool(cv_setting_plant .."cucumber", true)
-cucina_vegana.plant_settings.cucumber_scale = minetest.settings:get(cv_setting_plant .."cucumber_scale") or 0.0004
-cucina_vegana.plant_settings.cucumber_light = minetest.settings:get(cv_setting_plant .."cucumber_light") or 12
+cucina_vegana.plant_settings.cucumber = core.settings:get_bool(cv_setting_plant .."cucumber", true)
+cucina_vegana.plant_settings.cucumber_scale = core.settings:get(cv_setting_plant .."cucumber_scale") or 0.0004
+cucina_vegana.plant_settings.cucumber_light = core.settings:get(cv_setting_plant .."cucumber_light") or 12
 
 -- Strawberry
-cucina_vegana.plant_settings.strawberry = minetest.settings:get_bool(cv_setting_plant .. "strawberry", true)
-cucina_vegana.plant_settings.strawberry_scale = minetest.settings:get(cv_setting_plant .."strawberry_scale") or 0.006
-cucina_vegana.plant_settings.strawberry_light = minetest.settings:get(cv_setting_plant .."strawberry_light") or 10
+cucina_vegana.plant_settings.strawberry = core.settings:get_bool(cv_setting_plant .. "strawberry", true)
+cucina_vegana.plant_settings.strawberry_scale = core.settings:get(cv_setting_plant .."strawberry_scale") or 0.006
+cucina_vegana.plant_settings.strawberry_light = core.settings:get(cv_setting_plant .."strawberry_light") or 10
 
 --  ********************************************************
 --  ***                    shrubs                        ***
 --  ********************************************************
 
 -- Vine
-cucina_vegana.shrub_settings.vine = minetest.settings:get_bool(cv_setting_shrub .. "vine", true)
-cucina_vegana.shrub_settings.vine_scale = minetest.settings:get(cv_setting_shrub .. "vine_scale") or 0.008
-cucina_vegana.shrub_settings.vine_light = minetest.settings:get(cv_setting_shrub .. "vine_light") or 12
-cucina_vegana.shrub_settings.vine_duration = minetest.settings:get(cv_setting_shrub .. "vine_duration") or 120
+cucina_vegana.shrub_settings.vine = core.settings:get_bool(cv_setting_shrub .. "vine", true)
+cucina_vegana.shrub_settings.vine_scale = core.settings:get(cv_setting_shrub .. "vine_scale") or 0.008
+cucina_vegana.shrub_settings.vine_light = core.settings:get(cv_setting_shrub .. "vine_light") or 12
+cucina_vegana.shrub_settings.vine_duration = core.settings:get(cv_setting_shrub .. "vine_duration") or 120
 
 -- Coffee
-cucina_vegana.shrub_settings.coffee = minetest.settings:get_bool(cv_setting_shrub .. "coffee", true)
-cucina_vegana.shrub_settings.coffee_scale = minetest.settings:get(cv_setting_shrub .. "coffee_scale") or 0.005
-cucina_vegana.shrub_settings.coffee_light = minetest.settings:get(cv_setting_shrub .. "coffee_light") or 11
-cucina_vegana.shrub_settings.coffee_duration = minetest.settings:get(cv_setting_shrub .. "coffee_duration") or 180
+cucina_vegana.shrub_settings.coffee = core.settings:get_bool(cv_setting_shrub .. "coffee", true)
+cucina_vegana.shrub_settings.coffee_scale = core.settings:get(cv_setting_shrub .. "coffee_scale") or 0.005
+cucina_vegana.shrub_settings.coffee_light = core.settings:get(cv_setting_shrub .. "coffee_light") or 11
+cucina_vegana.shrub_settings.coffee_duration = core.settings:get(cv_setting_shrub .. "coffee_duration") or 180
 

--- a/soy.lua
+++ b/soy.lua
@@ -22,7 +22,7 @@ farming.register_plant("cucina_vegana:".. pname, {
 })
 
 -- Register for Mapgen
-minetest.register_node("cucina_vegana:wild_".. pname, {
+core.register_node("cucina_vegana:wild_".. pname, {
 	description = S("Wild") .. " " .. dname,
 	paramtype = "light",
 	walkable = false,
@@ -50,9 +50,9 @@ minetest.register_node("cucina_vegana:wild_".. pname, {
 
 cucina_vegana.add_group("cucina_vegana:seed_"..pname, {seed_soy = 1})
 
-minetest.register_alias("soy:wild_".. pname, "cucina_vegana:wild_".. pname)
-minetest.register_alias("soy:".. pname, "cucina_vegana:".. pname)
-minetest.register_alias("soy:seed_".. pname, "cucina_vegana:seed_".. pname)
+core.register_alias("soy:wild_".. pname, "cucina_vegana:wild_".. pname)
+core.register_alias("soy:".. pname, "cucina_vegana:".. pname)
+core.register_alias("soy:seed_".. pname, "cucina_vegana:seed_".. pname)
 
 if(cucina_vegana.plant_settings.bonemeal) then
     table.insert(cucina_vegana.plant_settings.bonemeal_list,
@@ -71,7 +71,7 @@ if(cucina_vegana.signs_bot) then
     cucina_vegana.register_signs_bot(pname, 1, step)
 end
 
-minetest.register_decoration({
+core.register_decoration({
 	deco_type = "simple",
 	place_on = {"default:dirt_with_grass"},
 	sidelen = 16,

--- a/strawberry.lua
+++ b/strawberry.lua
@@ -23,7 +23,7 @@ farming.register_plant("cucina_vegana:" .. pname, {
 })
 
 -- Register for Mapgen
-minetest.register_node("cucina_vegana:wild_" .. pname, {
+core.register_node("cucina_vegana:wild_" .. pname, {
 	description = S("Wild") .. " " .. dname,
 	paramtype = "light",
 	walkable = false,
@@ -66,7 +66,7 @@ if(cucina_vegana.signs_bot) then
 
 end
 
-minetest.register_decoration({
+core.register_decoration({
 	deco_type = "simple",
 	place_on = {"default:dirt_with_grass", "default:dirt_with_rainforest_litter", "default:dirt_with_coniferous_litter", "default:dirt_with_dry_grass"},
 	spawn_by = {"default:tree", "default:aspen_tree", "default:jungletree", "default:fernt_1", "default:fern_2", "default:fern_3"},

--- a/sunflower.lua
+++ b/sunflower.lua
@@ -1,16 +1,16 @@
-local modpath = minetest.get_modpath(minetest.get_current_modname())
+local modpath = core.get_modpath(core.get_current_modname())
 
-if(minetest.registered_nodes["flowers:sunflower"]  ~= nil) then
-	print("[MOD] " .. minetest.get_current_modname() .. " Sunflowers available.")
-	print("[MOD] " .. minetest.get_current_modname() .. " using \"flowers:sunflower\".")
+if(core.registered_nodes["flowers:sunflower"]  ~= nil) then
+	print("[MOD] " .. core.get_current_modname() .. " Sunflowers available.")
+	print("[MOD] " .. core.get_current_modname() .. " using \"flowers:sunflower\".")
 
 else
 
-	print("[MOD] " .. minetest.get_current_modname() .. " no Sunflowers available.")
-	print("[MOD] " .. minetest.get_current_modname() .. " use own Sunflowers.")
+	print("[MOD] " .. core.get_current_modname() .. " no Sunflowers available.")
+	print("[MOD] " .. core.get_current_modname() .. " use own Sunflowers.")
 
 
-	minetest.register_decoration({
+	core.register_decoration({
 		deco_type = "simple",
 		place_on = {"default:dirt_with_grass", "default:dirt_with_dry_grass"},
 		sidelen = 16,
@@ -27,7 +27,7 @@ else
 		decoration = "cucina_vegana:wild_sunflower",
 		})
 
-	minetest.register_alias("flowers:sunflower", "cucina_vegana:sunflower")
+	core.register_alias("flowers:sunflower", "cucina_vegana:sunflower")
 
 
 		dofile(modpath .. "/sunflower_def.lua")

--- a/sunflower_def.lua
+++ b/sunflower_def.lua
@@ -10,12 +10,12 @@ local S = cucina_vegana.get_translator
 local dname = S("Sunflower")
 local pname = "sunflower"
 local step = 5
-local modname = minetest.get_current_modname()
+local modname = core.get_current_modname()
 
-if(minetest.registered_nodes["flowers:sunflower"]  ~= nil) then
+if(core.registered_nodes["flowers:sunflower"]  ~= nil) then
 	print("[MOD] " .. modname .. " Sunflowers available.")
 	print("[MOD] " .. modname .. " using \"flowers:sunflower\".")
-    minetest.log("info", "[MOD] " .. modname .. ": Sunflowers available. Using \"flowers:sunflower\".")
+    core.log("info", "[MOD] " .. modname .. ": Sunflowers available. Using \"flowers:sunflower\".")
 
 else
 
@@ -30,7 +30,7 @@ else
 	})
 
 	-- Register for Mapgen
-	minetest.register_node("cucina_vegana:wild_" .. pname, {
+	core.register_node("cucina_vegana:wild_" .. pname, {
 		description = S("Wild") .. " " .. dname,
 		paramtype = "light",
 		walkable = false,
@@ -55,8 +55,8 @@ else
 		},
 	})
 
-	minetest.override_item("cucina_vegana:" .. pname .. "_4", {visual_scale = 1.3})
-	minetest.override_item("cucina_vegana:" .. pname .. "_5", {visual_scale = 1.5})
+	core.override_item("cucina_vegana:" .. pname .. "_4", {visual_scale = 1.3})
+	core.override_item("cucina_vegana:" .. pname .. "_5", {visual_scale = 1.5})
 
 end
 

--- a/tomato.lua
+++ b/tomato.lua
@@ -23,7 +23,7 @@ farming.register_plant("cucina_vegana:" .. pname, {
 })
 
 -- Register for Mapgen
-minetest.register_node("cucina_vegana:wild_" .. pname, {
+core.register_node("cucina_vegana:wild_" .. pname, {
 	description = S("Wild") .. " " .. dname,
 	paramtype = "light",
 	walkable = false,
@@ -68,7 +68,7 @@ if(cucina_vegana.signs_bot) then
 
 end
 
-minetest.register_decoration({
+core.register_decoration({
 	deco_type = "simple",
 	place_on = {"default:dirt_with_grass", "default:dry_dirt_with_dry_grass"},
 	sidelen = 16,

--- a/tools.lua
+++ b/tools.lua
@@ -22,16 +22,16 @@ function cucina_vegana.add_group(node, entry)
     if(type(node) ~= "string") then return end
 
     -- Check the Item and get the group
-    if(minetest.registered_items[node] ~= nil) then
-        newgroup = cucina_vegana.table_clone(minetest.registered_items[node].groups)
+    if(core.registered_items[node] ~= nil) then
+        newgroup = cucina_vegana.table_clone(core.registered_items[node].groups)
 
-    elseif(minetest.registered_tools[node] ~= nil) then
-        newgroup = cucina_vegana.table_clone(minetest.registered_tools[node].groups)
+    elseif(core.registered_tools[node] ~= nil) then
+        newgroup = cucina_vegana.table_clone(core.registered_tools[node].groups)
 
     else -- Node not found.
         return
 
-    end -- if(minetest.registered_nodes
+    end -- if(core.registered_nodes
 
     -- add the new groups to the item
     for key,value in pairs(entry) do
@@ -39,7 +39,7 @@ function cucina_vegana.add_group(node, entry)
 
     end
 
-    minetest.override_item(node, {
+    core.override_item(node, {
                                   groups = newgroup
                                  })
 
@@ -74,6 +74,6 @@ function cucina_vegana.register_farming_ng(pname, step)
     end -- if cucina_vegana.farming_default
 
     print("info", "[MOD] " .. modname .. ": cucina_vegana:seed_" .. pname .. " at farming_nextgen registered.")
-    minetest.log("info", "[MOD] " .. modname .. ": cucina_vegana:seed_" .. pname .. " at farming_nextgen registered.")
+    core.log("info", "[MOD] " .. modname .. ": cucina_vegana:seed_" .. pname .. " at farming_nextgen registered.")
 
 end -- cucina_vegana.register_farming_ng(

--- a/vine.lua
+++ b/vine.lua
@@ -1,5 +1,4 @@
-
-minetest.register_decoration({
+core.register_decoration({
 	deco_type = "simple",
 	place_on = {"default:dirt_with_grass", "default:dirt", "default:dry_dirt", "default:dirt_with_dry_grass"},
 	sidelen = 16,

--- a/vine_def.lua
+++ b/vine_def.lua
@@ -5,7 +5,6 @@
 ]]--
 
 local cv = cucina_vegana
-local mt = minetest
 
 -- Load support for intllib.
 local S = cv.get_translator
@@ -19,7 +18,7 @@ local maxlight = cv.shrub_settings.vine_light
 local percent = 3
 
 -- Register for Mapgen
-mt.register_node("cucina_vegana:wild_" .. pname, {
+core.register_node("cucina_vegana:wild_" .. pname, {
 	description = S("Wild" ) .. " " .. dname .. " " .. S("Stem"),
 	paramtype = "light",
 	walkable = true,
@@ -45,7 +44,7 @@ mt.register_node("cucina_vegana:wild_" .. pname, {
 	},
 })
 
-mt.register_node("cucina_vegana:" .. pname .. "_leaves", {
+core.register_node("cucina_vegana:" .. pname .. "_leaves", {
 	description = dname .. " " .. S("Leaves"),
 	paramtype = "light",
 	walkable = true,
@@ -78,15 +77,15 @@ mt.register_node("cucina_vegana:" .. pname .. "_leaves", {
 						end,
 })
 
-mt.register_craftitem("cucina_vegana:" .. pname .. "_grape", {
+core.register_craftitem("cucina_vegana:" .. pname .. "_grape", {
 	description = S("Grape"),
 	inventory_image = "cucina_vegana_" .. pname .. "_grape.png",
 	groups = {food = 1, food_wine = 1},
-    on_use = mt.item_eat(3)
+    on_use = core.item_eat(3)
 
 })
 
-mt.register_node("cucina_vegana:" .. pname .. "_sapling", {
+core.register_node("cucina_vegana:" .. pname .. "_sapling", {
 	description = dname .. " " .. S("Sapling"),
 	paramtype = "light",
 	walkable = true,
@@ -111,7 +110,7 @@ mt.register_node("cucina_vegana:" .. pname .. "_sapling", {
 cv.lib.register_bottom_abm("cucina_vegana:" .. pname .. "_sapling", "cucina_vegana:" .. pname .. "_bottom_1", duration, maxlight)
 
 for step = 1, bottom_steps do
-	mt.register_node("cucina_vegana:" .. pname .. "_bottom_" .. step, {
+	core.register_node("cucina_vegana:" .. pname .. "_bottom_" .. step, {
 		description = dname,
 		paramtype = "light",
 		walkable = true,
@@ -143,7 +142,7 @@ for step = 1, bottom_steps do
 
 end -- for step
 
-mt.register_abm({
+core.register_abm({
     nodenames = {"cucina_vegana:" .. pname .. "_bottom_" .. bottom_steps},
     interval = duration,
     chance = percent,
@@ -152,7 +151,7 @@ mt.register_abm({
                 local nodepos = { x = pos.x, y = pos.y+1, z = pos.z}
 	                if(cv.lib.check_light(nodepos, maxlight)) then
                         if(cv.lib.check_air(nodepos)) then
-                            mt.set_node(nodepos, {name = "cucina_vegana:" .. pname .. "_top_1"})
+                            core.set_node(nodepos, {name = "cucina_vegana:" .. pname .. "_top_1"})
 
                         end -- if(check_air)
 
@@ -160,10 +159,10 @@ mt.register_abm({
 
             end, -- function(
 
-}) -- minetest.register_abm({
+}) -- core.register_abm({
 
 for step = 1, top_steps do
-	mt.register_node("cucina_vegana:" .. pname .. "_top_" .. step, {
+	core.register_node("cucina_vegana:" .. pname .. "_top_" .. step, {
 		description = dname,
 		paramtype = "light",
 		walkable = false,


### PR DESCRIPTION
This PR replaces every instance where the namespace `minetest.` is used into `core.`

Luanti/Minetest has supported this internally in `builtin/` since 0.4.10 I believe, so changing it won't mess anything up or break anything.

Part 2 will be some general code style fixes like indentation :)

@acmgit