### PR TITLE
Cleanup [Part 2]: Various code style and indentation fixes

### DIFF
--- a/aliases.lua
+++ b/aliases.lua
@@ -1,2 +1,1 @@
-
 core.register_alias("cucina_vegana:corn_cob", "cucina_vegana:corn")

--- a/asparagus.lua
+++ b/asparagus.lua
@@ -28,42 +28,45 @@ core.register_node("cucina_vegana:wild_" .. pname, {
 	paramtype = "light",
 	walkable = false,
 	drop = {
-			items = {
-					{items = {"cucina_vegana:seed_" .. pname .. " 3"}},
-					{items = {"cucina_vegana:" .. pname .. ""}},
-				}
-			},
+		items = {
+			{items = {"cucina_vegana:seed_" .. pname .. " 3"}},
+			{items = {"cucina_vegana:" .. pname .. ""}},
+		}
+	},
 	drawtype = "plantlike",
 	paramtype2 = "facedir",
 	tiles = {"cucina_vegana_" .. pname .. "_" .. step .. ".png"},
 	sunlight_propagates = true,
-	groups = {snappy = 3, dig_immediate=1, flammable=2, plant=1, attached_node = 1,
-                growing = 1, not_in_creative_inventory = 1},
+	groups = {
+		snappy = 3, dig_immediate = 1, flammable = 2, plant = 1, 
+		attached_node = 1, growing = 1, not_in_creative_inventory = 1
+	},
 	sounds = default.node_sound_leaves_defaults(),
 	selection_box = {
-			type = "fixed",
-			fixed = {
-				{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
-			},
+		type = "fixed",
+		fixed = {
+			{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
+		},
 	},
 })
 
-if(cucina_vegana.plant_settings.bonemeal) then
-    table.insert(cucina_vegana.plant_settings.bonemeal_list,
-								{"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:seed_" .. pname})
-
-end -- if(cucina_vegana.plant_settings.bonemeal
+if cucina_vegana.plant_settings.bonemeal then
+	local table = {
+		"cucina_vegana:" .. pname .. "_",
+		step,
+		"cucina_vegana:seed_" .. pname
+	}
+    table.insert(cucina_vegana.plant_settings.bonemeal_list, table)
+end
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then
     cucina_vegana.register_farming_ng(pname, step)
-
-end -- if(cucina_vegana.farming_ng
+end
 
 -- Register @ Signs_bot
-if(cucina_vegana.signs_bot) then
+if cucina_vegana.signs_bot then
     cucina_vegana.register_signs_bot(pname, 1, step)
-
 end
 
 core.register_decoration({

--- a/banana.lua
+++ b/banana.lua
@@ -33,43 +33,46 @@ core.register_node("cucina_vegana:wild_" .. pname, {
 	paramtype = "light",
 	walkable = false,
 	drop = {
-			items = {
-					{items = {"cucina_vegana:seed_" .. pname .. " 3"}},
-					{items = {"cucina_vegana:" .. pname .. ""}},
-				}
-			},
+		items = {
+			{items = {"cucina_vegana:seed_" .. pname .. " 3"}},
+			{items = {"cucina_vegana:" .. pname .. ""}},
+		}
+	},
 	drawtype = "plantlike",
 	paramtype2 = "facedir",
 	tiles = {"cucina_vegana_" .. pname .. "_" .. step .. ".png"},
 	sunlight_propagates = true,
-	groups = {snappy = 3, dig_immediate=1, flammable=2, plant=1, attached_node = 1,
-                growing = 1, not_in_creative_inventory = 1},
+	groups = {
+		snappy = 3, dig_immediate = 1, flammable = 2, plant = 1,
+		attached_node = 1, growing = 1, not_in_creative_inventory = 1
+	},
 	sounds = default.node_sound_leaves_defaults(),
 	selection_box = {
-			type = "fixed",
-			fixed = {
-				{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
-			},
+		type = "fixed",
+		fixed = {
+			{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
+		},
 	},
 	visual_scale = 1.9,
 })
 
-if(cucina_vegana.plant_settings.bonemeal) then
-    table.insert(cucina_vegana.plant_settings.bonemeal_list,
-								{"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:seed_" .. pname})
-
-end -- if(cucina_vegana.plant_settings.bonemeal
+if cucina_vegana.plant_settings.bonemeal then
+	local table = {
+		"cucina_vegana:" .. pname .. "_",
+		step,
+		"cucina_vegana:seed_" .. pname
+	}
+    table.insert(cucina_vegana.plant_settings.bonemeal_list, table)
+end
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then
     cucina_vegana.register_farming_ng(pname, step)
-
-end -- if(cucina_vegana.farming_ng
+end
 
 -- Register @ Signs_bot
-if(cucina_vegana.signs_bot) then
+if cucina_vegana.signs_bot then
     cucina_vegana.register_signs_bot(pname, 1, step)
-
 end
 
 -- mapgen

--- a/carrot.lua
+++ b/carrot.lua
@@ -28,44 +28,47 @@ core.register_node("cucina_vegana:wild_" .. pname, {
 	paramtype = "light",
 	walkable = false,
 	drop = {
-			items = {
-					{items = {"cucina_vegana:seed_" .. pname .. " 4"}},
-					{items = {"cucina_vegana:" .. pname .. " 3"}},
-				}
-			},
+		items = {
+			{items = {"cucina_vegana:seed_" .. pname .. " 4"}},
+			{items = {"cucina_vegana:" .. pname .. " 3"}},
+		}
+	},
 	drawtype = "plantlike",
 	paramtype2 = "facedir",
 	sunlight_propagates = true,
 	tiles = {"cucina_vegana_" .. pname .. "_" .. step .. ".png"},
-	groups = {snappy = 3, dig_immediate=1, flammable=2, plant=1, attached_node = 1,
-                growing = 1, not_in_creative_inventory = 1},
+	groups = {
+		snappy = 3, dig_immediate = 1, flammable = 2, plant = 1,
+		attached_node = 1, growing = 1, not_in_creative_inventory = 1
+	},
 	sounds = default.node_sound_leaves_defaults(),
 	selection_box = {
-			type = "fixed",
-			fixed = {
-				{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
-			},
+		type = "fixed",
+		fixed = {
+			{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
+		},
 	},
 })
 
 cucina_vegana.add_group("cucina_vegana:seed_" .. pname, {seed_carrot = 1})
 
-if(cucina_vegana.plant_settings.bonemeal) then
-    table.insert(cucina_vegana.plant_settings.bonemeal_list,
-                 {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:seed_" .. pname})
-
-end -- if(cucina_vegana.plant_settings.bonemeal
+if cucina_vegana.plant_settings.bonemeal then
+	local table = {
+		"cucina_vegana:" .. pname .. "_",
+		step,
+		"cucina_vegana:seed_" .. pname
+	}
+    table.insert(cucina_vegana.plant_settings.bonemeal_list, table)
+end
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then
     cucina_vegana.register_farming_ng(pname, step)
-
-end -- if(cucina_vegana.farming_ng
+end
 
 -- Register @ Signs_bot
-if(cucina_vegana.signs_bot) then
-        cucina_vegana.register_signs_bot(pname, 1, step)
-
+if cucina_vegana.signs_bot then
+    cucina_vegana.register_signs_bot(pname, 1, step)
 end
 
 core.register_decoration({

--- a/chili.lua
+++ b/chili.lua
@@ -28,44 +28,47 @@ core.register_node("cucina_vegana:wild_" .. pname, {
 	paramtype = "light",
 	walkable = false,
 	drop = {
-			items = {
-					{items = {"cucina_vegana:seed_" .. pname .. " 4"}},
-					{items = {"cucina_vegana:" .. pname .. " 2"}},
-				}
-			},
+		items = {
+			{items = {"cucina_vegana:seed_" .. pname .. " 4"}},
+			{items = {"cucina_vegana:" .. pname .. " 2"}},
+		}
+	},
 	drawtype = "plantlike",
 	paramtype2 = "facedir",
 	sunlight_propagates = true,
 	tiles = {"cucina_vegana_" .. pname .. "_" .. step .. ".png"},
-	groups = {snappy = 3, dig_immediate=1, flammable=2, plant=1, attached_node = 1,
-                growing = 1, not_in_creative_inventory = 1},
+	groups = {
+		snappy = 3, dig_immediate = 1, flammable = 2, plant = 1,
+		attached_node = 1, growing = 1, not_in_creative_inventory = 1
+	},
 	sounds = default.node_sound_leaves_defaults(),
 	selection_box = {
-			type = "fixed",
-			fixed = {
-				{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
-			},
+		type = "fixed",
+		fixed = {
+			{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
+		},
 	},
 })
 
 cucina_vegana.add_group("cucina_vegana:seed_" .. pname, {seed_chili = 1})
 
-if(cucina_vegana.plant_settings.bonemeal) then
-    table.insert(cucina_vegana.plant_settings.bonemeal_list,
-                 {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:seed_" .. pname})
-
-end -- if(cucina_vegana.plant_settings.bonemeal
+if cucina_vegana.plant_settings.bonemeal then
+	local table = {
+		"cucina_vegana:" .. pname .. "_",
+		step,
+		"cucina_vegana:seed_" .. pname
+	}
+    table.insert(cucina_vegana.plant_settings.bonemeal_list, table)
+end
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then
     cucina_vegana.register_farming_ng(pname, step)
-
-end -- if(cucina_vegana.farming_ng
+end
 
 -- Register @ Signs_bot
-if(cucina_vegana.signs_bot) then
-        cucina_vegana.register_signs_bot(pname, 1, step)
-
+if cucina_vegana.signs_bot then
+    cucina_vegana.register_signs_bot(pname, 1, step)
 end
 
 core.register_decoration({

--- a/chives.lua
+++ b/chives.lua
@@ -28,43 +28,45 @@ core.register_node("cucina_vegana:wild_" .. pname, {
 	paramtype = "light",
 	walkable = false,
 	drop = {
-			items = {
-					{items = {"cucina_vegana:seed_" .. pname .. " 3"}},
-					{items = {"cucina_vegana:" .. pname}},
-				}
-			},
+		items = {
+			{items = {"cucina_vegana:seed_" .. pname .. " 3"}},
+			{items = {"cucina_vegana:" .. pname}},
+		}
+	},
 	drawtype = "plantlike",
 	paramtype2 = "facedir",
 	sunlight_propagates = true,
 	tiles = {"cucina_vegana_" .. pname .. "_" .. step .. ".png"},
-	groups = {snappy = 3, dig_immediate=1, flammable=2, plant=1, attached_node = 1,
-                growing = 1, not_in_creative_inventory = 1},
+	groups = {
+		snappy = 3, dig_immediate = 1, flammable = 2, plant = 1,
+		attached_node = 1, growing = 1, not_in_creative_inventory = 1
+	},
 	sounds = default.node_sound_leaves_defaults(),
 	selection_box = {
-			type = "fixed",
-			fixed = {
-				{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
-			},
+		type = "fixed",
+		fixed = {
+			{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
+		},
 	},
 })
 
-if(cucina_vegana.plant_settings.bonemeal) then
-    table.insert(cucina_vegana.plant_settings.bonemeal_list,
-                 {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:seed_" .. pname})
-
-end -- if(cucina_vegana.plant_settings.bonemeal
+if cucina_vegana.plant_settings.bonemeal then
+	local table = {
+		"cucina_vegana:" .. pname .. "_",
+		step,
+		"cucina_vegana:seed_" .. pname
+	}
+    table.insert(cucina_vegana.plant_settings.bonemeal_list, table)
+end
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then
     cucina_vegana.register_farming_ng(pname, step)
-
-end -- if(cucina_vegana.farming_ng
+end
 
 -- Register @ Signs_bot
-if(cucina_vegana.signs_bot) then
-        cucina_vegana.register_signs_bot(pname, 1, step)
-
-
+if cucina_vegana.signs_bot then
+    cucina_vegana.register_signs_bot(pname, 1, step)
 end
 
 core.register_decoration({

--- a/coffee_def.lua
+++ b/coffee_def.lua
@@ -24,23 +24,25 @@ core.register_node("cucina_vegana:wild_" .. pname, {
 	walkable = true,
 	climbable = true,
 	drop = {
-			items = {
-					{items = {"cucina_vegana:" .. pname .. "_beans_raw 4"}},
-					{items = {"cucina_vegana:" .. pname .. "_sapling 1"}},
-				}
-			},
+		items = {
+			{items = {"cucina_vegana:" .. pname .. "_beans_raw 4"}},
+			{items = {"cucina_vegana:" .. pname .. "_sapling 1"}},
+		}
+	},
 	drawtype = "plantlike",
 	paramtype2 = "facedir",
 	sunlight_propagates = true,
 	tiles = {"cucina_vegana_" .. pname .. "_bottom_1.png"},
-	groups = {snappy = 3, dig_immediate=1, flammable=2, plant=1, attached_node = 1,
-                growing = 1, not_in_creative_inventory = 1},
+	groups = {
+		snappy = 3, dig_immediate = 1, flammable = 2, plant = 1,
+		attached_node = 1, growing = 1, not_in_creative_inventory = 1
+	},
 	sounds = default.node_sound_leaves_defaults(),
 	selection_box = {
-			type = "fixed",
-			fixed = {
-				{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
-			},
+		type = "fixed",
+		fixed = {
+			{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
+		},
 	},
 })
 
@@ -73,8 +75,8 @@ core.register_node("cucina_vegana:" .. pname .. "_leaves", {
 		}
 	},
 	after_place_node = function(...)
-							return default.after_place_leaves(...)
-						end,
+		return default.after_place_leaves(...)
+	end,
 })
 
 core.register_craftitem("cucina_vegana:" .. pname .. "_beans_raw", {
@@ -82,7 +84,6 @@ core.register_craftitem("cucina_vegana:" .. pname .. "_beans_raw", {
 	inventory_image = "cucina_vegana_" .. pname .. "_beans_raw.png",
 	groups = {food = 1, food_coffee = 1},
     on_use = core.item_eat(3)
-
 })
 
 core.register_node("cucina_vegana:" .. pname .. "_sapling", {
@@ -96,8 +97,14 @@ core.register_node("cucina_vegana:" .. pname .. "_sapling", {
 	tiles = {"cucina_vegana_" .. pname .. "_sapling.png"},
 	inventory_image = "cucina_vegana_" .. pname .. "_sapling.png",
 	wield_image = "cucina_vegana_" .. pname .. "_sapling.png",
-	groups = {	snappy = 3, dig_immediate=1, flammable=2, plant=1, attached_node = 1,
-                growing = 1},
+	groups = {
+		snappy = 3,
+		dig_immediate = 1,
+		flammable = 2,
+		plant = 1,
+		attached_node = 1,
+        growing = 1
+	},
 	sounds = default.node_sound_leaves_defaults(),
 	selection_box = {
 		type = "fixed",
@@ -105,10 +112,13 @@ core.register_node("cucina_vegana:" .. pname .. "_sapling", {
 			{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
 		},
 	},
-
 })
 
-cv.lib.register_bottom_abm("cucina_vegana:" .. pname .. "_sapling", "cucina_vegana:" .. pname .. "_bottom_1", duration, maxlight)
+cv.lib.register_bottom_abm(
+	"cucina_vegana:" .. pname .. "_sapling",
+	"cucina_vegana:" .. pname .. "_bottom_1",
+	duration, maxlight
+)
 
 for step = 1, bottom_steps do
 	core.register_node("cucina_vegana:" .. pname .. "_bottom_" .. step, {
@@ -118,30 +128,38 @@ for step = 1, bottom_steps do
 		climbable = true,
 		drop = {
 			items = {
-					{items = {"cucina_vegana:" .. pname .. "_sapling 1"}},
+				{items = {"cucina_vegana:" .. pname .. "_sapling 1"}},
 			},
 		},
 		drawtype = "plantlike",
 		paramtype2 = "facedir",
 		sunlight_propagates = true,
 		tiles = {"cucina_vegana_" .. pname .. "_bottom_" .. step .. ".png"},
-		groups = {	snappy = 3, flammable=2, plant=1, attached_node = 1,
-	                growing = 1, not_in_creative_inventory = 1},
+		groups = {
+			snappy = 3,
+			flammable = 2,
+			plant = 1,
+			attached_node = 1,
+	        growing = 1,
+			not_in_creative_inventory = 1
+		},
 		sounds = default.node_sound_leaves_defaults(),
 		selection_box = {
 			type = "fixed",
 			fixed = {
-						{-0.4, -0.5, -0.4, 0.4, 0.5, 0.4}, -- side f
-					},
+				{-0.4, -0.5, -0.4, 0.4, 0.5, 0.4}, -- side f
+			},
 		},
 	})
 
-	if (step < bottom_steps) then
-		cv.lib.register_bottom_abm("cucina_vegana:" .. pname .. "_bottom_" .. step, "cucina_vegana:" .. pname .. "_bottom_" .. step+1, duration, maxlight)
-
+	if step < bottom_steps then
+		cv.lib.register_bottom_abm(
+			"cucina_vegana:" .. pname .. "_bottom_" .. step,
+			"cucina_vegana:" .. pname .. "_bottom_" .. step + 1,
+			duration, maxlight
+		)
 	end
-
-end -- for step
+end
 
 core.register_abm({
     nodenames = {"cucina_vegana:" .. pname .. "_bottom_" .. bottom_steps},
@@ -149,18 +167,16 @@ core.register_abm({
     chance = percent,
     catch_up = true,
     action = function(pos, node, active_object_count, active_object_count_wider)
-                local nodepos = { x = pos.x, y = pos.y+1, z = pos.z}
-	                if(cv.lib.check_light(nodepos, maxlight)) then
-                        if(cv.lib.check_air(nodepos)) then
-                            core.set_node(nodepos, {name = "cucina_vegana:" .. pname .. "_top_1"})
-
-                        end -- if(check_air)
-
-                    end -- if(cv.check_light
-
-            end, -- function(
-
-}) -- core.register_abm({
+        local nodepos = { x = pos.x, y = pos.y+1, z = pos.z}
+	    if cv.lib.check_light(nodepos, maxlight) then
+            if cv.lib.check_air(nodepos)  then
+                core.set_node(nodepos, {
+					name = "cucina_vegana:" .. pname .. "_top_1"
+				})
+            end
+        end
+    end,
+})
 
 for step = 1, top_steps do
 	core.register_node("cucina_vegana:" .. pname .. "_top_" .. step, {
@@ -169,35 +185,44 @@ for step = 1, top_steps do
 		walkable = false,
 		drop = {
 			items = {
-						{items = {"cucina_vegana:" .. pname .. "_leaves 3"}},
-						{items = {"cucina_vegana:" .. pname .. "_beans_raw 2"}},
-						{items = {"cucina_vegana:" .. pname .. "_beans_raw 5"}, rarity = top_steps-step},
-						{items = {"cucina_vegana:" .. pname .. "_sapling 2"}, rarity = 4},
-					},
-				},
+				{items = {"cucina_vegana:" .. pname .. "_leaves 3"}},
+				{items = {"cucina_vegana:" .. pname .. "_beans_raw 2"}},
+				{items = {"cucina_vegana:" .. pname .. "_beans_raw 5"}, rarity = top_steps-step},
+				{items = {"cucina_vegana:" .. pname .. "_sapling 2"}, rarity = 4},
+			},
+		},
 		drawtype = "plantlike",
 		paramtype2 = "facedir",
 		sunlight_propagates = true,
 		tiles = {"cucina_vegana_" .. pname .. "_top_" .. step .. ".png"},
-		groups = {	snappy = 3, dig_immediate=1, flammable=2, plant=1, attached_node = 1,
-	                growing = 1, not_in_creative_inventory = 1, tree = 1},
+		groups = {
+			snappy = 3,
+			dig_immediate = 1,
+			flammable = 2,
+			plant = 1,
+			attached_node = 1,
+	        growing = 1,
+			not_in_creative_inventory = 1,
+			tree = 1
+		},
 		sounds = default.node_sound_leaves_defaults(),
 		selection_box = {
 			type = "fixed",
 			fixed = {
-						{-0.4, -0.5, -0.4, 0.4, 0.5, 0.4}, -- side f
-					},
+				{-0.4, -0.5, -0.4, 0.4, 0.5, 0.4}, -- side f
+			},
 		},
 	})
 
-	if (step < top_steps) then
-		cv.lib.register_top_abm("cucina_vegana:" .. pname .. "_top_" .. step, "cucina_vegana:" .. pname .. "_top_" .. step+1, duration, maxlight)
-
+	if step < top_steps then
+		cv.lib.register_top_abm(
+			"cucina_vegana:" .. pname .. "_top_" .. step,
+			"cucina_vegana:" .. pname .. "_top_" .. step + 1,
+			duration, maxlight
+		)
 	end
-
-end -- for step
+end
 
 if cucina_vegana.farming_ng then
     cucina_vegana.register_farming_ng("cucina_vegana:" .. pname .. "_top_", top_steps)
-
-end -- if(cucina_vegana.farming_ng
+end

--- a/corn.lua
+++ b/corn.lua
@@ -32,43 +32,46 @@ core.register_node("cucina_vegana:wild_" .. pname, {
 	paramtype = "light",
 	walkable = false,
 	drop = {
-			items = {
-					{items = {"cucina_vegana:seed_" .. pname .. " 3"}},
-					{items = {"cucina_vegana:" .. pname .. " 4"}},
-				}
-			},
+		items = {
+			{items = {"cucina_vegana:seed_" .. pname .. " 3"}},
+			{items = {"cucina_vegana:" .. pname .. " 4"}},
+		}
+	},
 	drawtype = "plantlike",
 	paramtype2 = "facedir",
 	tiles = {"cucina_vegana_" .. pname .. "_" .. step .. ".png"},
 	sunlight_propagates = true,
-	groups = {snappy = 3, dig_immediate=1, flammable=2, plant=1, attached_node = 1,
-                growing = 1, not_in_creative_inventory = 1},
+	groups = {
+		snappy = 3, dig_immediate = 1, flammable = 2, plant = 1,
+		attached_node = 1, growing = 1, not_in_creative_inventory = 1
+	},
 	sounds = default.node_sound_leaves_defaults(),
 	selection_box = {
-			type = "fixed",
-			fixed = {
-				{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
-			},
+		type = "fixed",
+		fixed = {
+			{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
+		},
 	},
 	visual_scale = 1.9,
 })
 
-if(cucina_vegana.plant_settings.bonemeal) then
-    table.insert(cucina_vegana.plant_settings.bonemeal_list,
-								{"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:seed_" .. pname})
-
-end -- if(cucina_vegana.plant_settings.bonemeal
+if cucina_vegana.plant_settings.bonemeal then
+	local table = {
+		"cucina_vegana:" .. pname .. "_",
+		step,
+		"cucina_vegana:seed_" .. pname
+	}
+    table.insert(cucina_vegana.plant_settings.bonemeal_list, table)
+end
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then
     cucina_vegana.register_farming_ng(pname, step)
-
-end -- if(cucina_vegana.farming_ng
+end
 
 -- Register @ Signs_bot
-if(cucina_vegana.signs_bot) then
+if cucina_vegana.signs_bot then
     cucina_vegana.register_signs_bot(pname, 1, step)
-
 end
 
 core.register_decoration({

--- a/cucumber.lua
+++ b/cucumber.lua
@@ -28,42 +28,45 @@ core.register_node("cucina_vegana:wild_" .. pname, {
 	paramtype = "light",
 	walkable = false,
 	drop = {
-			items = {
-					{items = {"cucina_vegana:seed_" .. pname .. " 3"}},
-					{items = {"cucina_vegana:" .. pname .. " 2"}},
-				}
-			},
+		items = {
+			{items = {"cucina_vegana:seed_" .. pname .. " 3"}},
+			{items = {"cucina_vegana:" .. pname .. " 2"}},
+		}
+	},
 	drawtype = "plantlike",
 	paramtype2 = "facedir",
 	tiles = {"cucina_vegana_" .. pname .. "_" .. step .. ".png"},
 	sunlight_propagates = true,
-	groups = {snappy = 3, dig_immediate=1, flammable=2, plant=1, attached_node = 1,
-                growing = 1, not_in_creative_inventory = 1},
+	groups = {
+		snappy = 3, dig_immediate = 1, flammable = 2, plant = 1,
+		attached_node = 1, growing = 1, not_in_creative_inventory = 1
+	},
 	sounds = default.node_sound_leaves_defaults(),
 	selection_box = {
-			type = "fixed",
-			fixed = {
-				{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
-			},
+		type = "fixed",
+		fixed = {
+			{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
+		},
 	},
 })
 
-if(cucina_vegana.plant_settings.bonemeal) then
-    table.insert(cucina_vegana.plant_settings.bonemeal_list,
-								{"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:seed_" .. pname})
-
-end -- if(cucina_vegana.plant_settings.bonemeal
+if cucina_vegana.plant_settings.bonemeal then
+	local table = {
+		"cucina_vegana:" .. pname .. "_",
+		step,
+		"cucina_vegana:seed_" .. pname
+	}
+    table.insert(cucina_vegana.plant_settings.bonemeal_list, table)
+end
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then
     cucina_vegana.register_farming_ng(pname, step)
-
-end -- if(cucina_vegana.farming_ng
+end
 
 -- Register @ Signs_bot
-if(cucina_vegana.signs_bot) then
+if cucina_vegana.signs_bot then
     cucina_vegana.register_signs_bot(pname, 1, step)
-
 end
 
 core.register_decoration({

--- a/flax.lua
+++ b/flax.lua
@@ -11,7 +11,7 @@ local dname = S("Flax")
 local pname = "flax"
 local step = 6
 
--- flex
+-- flax
 farming.register_plant("cucina_vegana:" .. pname, {
 	description = dname .. " " .. S("Seed"),
     harvest_description = dname,
@@ -28,44 +28,42 @@ core.register_node("cucina_vegana:wild_" .. pname, {
 	paramtype = "light",
 	walkable = false,
 	drop = {
-			items = {
-					{items = {"cucina_vegana:seed_" .. pname .. " 4"}},
-					{items = {"cucina_vegana:" .. pname .. " 2"}},
-				}
-			},
+		items = {
+			{items = {"cucina_vegana:seed_" .. pname .. " 4"}},
+			{items = {"cucina_vegana:" .. pname .. " 2"}},
+		}
+	},
 	drawtype = "plantlike",
 	paramtype2 = "facedir",
 	sunlight_propagates = true,
 	tiles = {"cucina_vegana_" .. pname .. "_" .. step .. ".png"},
-	groups = {snappy = 3, dig_immediate=1, flammable=2, plant=1, attached_node = 1,
-                growing = 1, not_in_creative_inventory = 1},
+	groups = {
+		snappy = 3, dig_immediate = 1, flammable = 2, plant = 1,
+		attached_node = 1, growing = 1, not_in_creative_inventory = 1
+	},
 	sounds = default.node_sound_leaves_defaults(),
 	selection_box = {
-			type = "fixed",
-			fixed = {
-				{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
-			},
+		type = "fixed",
+		fixed = {
+			{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
+		},
 	},
 })
 
 cucina_vegana.add_group("cucina_vegana:seed_" .. pname, {seed_flax = 1})
 
-if(cucina_vegana.plant_settings.bonemeal) then
-    table.insert(cucina_vegana.plant_settings.bonemeal_list,
-                 {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:seed_" .. pname})
-
-end -- if(cucina_vegana.plant_settings.bonemeal
+if cucina_vegana.plant_settings.bonemeal then
+    table.insert(cucina_vegana.plant_settings.bonemeal_list, table)
+end
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then
     cucina_vegana.register_farming_ng(pname, step)
-
-end -- if(cucina_vegana.farming_ng
+end
 
 -- Register @ Signs_bot
-if(cucina_vegana.signs_bot) then
-        cucina_vegana.register_signs_bot(pname, 1, step)
-
+if cucina_vegana.signs_bot then
+    cucina_vegana.register_signs_bot(pname, 1, step)
 end
 
 core.register_decoration({

--- a/garlic.lua
+++ b/garlic.lua
@@ -28,44 +28,47 @@ core.register_node("cucina_vegana:wild_" .. pname, {
 	paramtype = "light",
 	walkable = false,
 	drop = {
-			items = {
-					{items = {"cucina_vegana:seed_" .. pname .. " 4"}},
-					{items = {"cucina_vegana:" .. pname .. " 2"}},
-				}
-			},
+		items = {
+			{items = {"cucina_vegana:seed_" .. pname .. " 4"}},
+			{items = {"cucina_vegana:" .. pname .. " 2"}},
+		}
+	},
 	drawtype = "plantlike",
 	paramtype2 = "facedir",
 	sunlight_propagates = true,
 	tiles = {"cucina_vegana_" .. pname .. "_" .. step .. ".png"},
-	groups = {snappy = 3, dig_immediate=1, flammable=2, plant=1, attached_node = 1,
-                growing = 1, not_in_creative_inventory = 1},
+	groups = {
+		snappy = 3, dig_immediate = 1, flammable = 2, plant = 1,
+		attached_node = 1, growing = 1, not_in_creative_inventory = 1
+	},
 	sounds = default.node_sound_leaves_defaults(),
 	selection_box = {
-			type = "fixed",
-			fixed = {
-				{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
-			},
+		type = "fixed",
+		fixed = {
+			{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
+		},
 	},
 })
 
 cucina_vegana.add_group("cucina_vegana:seed_" .. pname, {seed_garlic = 1})
 
-if(cucina_vegana.plant_settings.bonemeal) then
-    table.insert(cucina_vegana.plant_settings.bonemeal_list,
-                 {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:seed_" .. pname})
-
-end -- if(cucina_vegana.plant_settings.bonemeal
+if cucina_vegana.plant_settings.bonemeal then
+	local table = {
+		"cucina_vegana:" .. pname .. "_",
+		step,
+		"cucina_vegana:seed_" .. pname
+	}
+    table.insert(cucina_vegana.plant_settings.bonemeal_list, table)
+end
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then
     cucina_vegana.register_farming_ng(pname, step)
-
-end -- if(cucina_vegana.farming_ng
+end
 
 -- Register @ Signs_bot
-if(cucina_vegana.signs_bot) then
-        cucina_vegana.register_signs_bot(pname, 1, step)
-
+if cucina_vegana.signs_bot then
+    cucina_vegana.register_signs_bot(pname, 1, step)
 end
 
 core.register_decoration({

--- a/init.lua
+++ b/init.lua
@@ -28,9 +28,12 @@ cucina_vegana.modname = core.get_current_modname()
 local modpath = core.get_modpath(core.get_current_modname())
 local modname = cucina_vegana.modname
 
+local has_bonemeal = core.get_modpath("bonemeal")
+local has_maidroid = core.get_modpath("maidroid")
+
 local S
 
-if(core.get_modpath("intllib")) then
+if core.get_modpath("intllib") then
     S = dofile(modpath .."/intllib.lua")
     core.log("info","[MOD] " .. modname .. ": translating in intllib-mode.")
 
@@ -39,9 +42,8 @@ elseif core.get_translator ~= nil then
     core.log("info", "[MOD] " .. modname .. ": translating in minetest-mode.")
 
 else
-    S = function ( s ) return s end
-
-end -- if(core.get_modpath(
+    S = function (s) return s end
+end
 
 cucina_vegana.get_translator = S
 
@@ -49,81 +51,76 @@ dofile(modpath .. "/settings.lua")
 dofile(modpath .. "/tools.lua")
 dofile(modpath .. "/lib.lua")
 
-if(cucina_vegana.signs_bot) then
+if cucina_vegana.signs_bot then
 	dofile(modpath .. "/register_signs_bot.lua")
 end
 
 -- looking if farming_redo is really activ? ... \/('')\/
-if(farming.mod ~= nil and farming.mod == "redo") then
+if farming.mod ~= nil and farming.mod == "redo" then
 	cucina_vegana.farming_default = false
     core.log("info", "[MOD] " .. modname .. ": farming_redo mode activated.")
 
 else
     core.log("info", "[MOD] " .. modname .. ": default farming mode activated.")
+end
 
-end -- if(farming.mod
+-- Enable support for bonemeal mod only if it is installed
+cucina_vegana.plant_settings.bonemeal = has_bonemeal or has_maidroid
 
-cucina_vegana.plant_settings.bonemeal = false         -- Support for bonemeal disabled
-if(core.get_modpath("bonemeal")) or core.get_modpath("maidroid") then
-    cucina_vegana.plant_settings.bonemeal = true
-
-end -- if(core.get_modpath("bonemeal"
+if has_bonemeal then
+    bonemeal:add_crop(cucina_vegana.plant_settings.bonemeal_list)
+end
 
 local plants = {
-
-			["asparagus"] = cucina_vegana.plant_settings.asparagus,
-			["chives"] = cucina_vegana.plant_settings.chives,
-			["flax"] = cucina_vegana.plant_settings.flax,
-			["kohlrabi"] = cucina_vegana.plant_settings.kohlrabi,
-			["lettuce"] = cucina_vegana.plant_settings.lettuce,
-			["parsley"] = cucina_vegana.plant_settings.parsley,
-            ["peanut"] = cucina_vegana.plant_settings.peanut,
-            ["rosemary"] = cucina_vegana.plant_settings.rosemary,
-			["rice"] = cucina_vegana.plant_settings.rice,
-			["soy"] = cucina_vegana.plant_settings.soy,
-			["sunflower"] = cucina_vegana.plant_settings.sunflower,
-            ["banana"] = cucina_vegana.plant_settings.banana,
-            ["tomato"] = cucina_vegana.plant_settings.tomato,
-            ["potato"] = cucina_vegana.plant_settings.potato,
-            ["carrot"] = cucina_vegana.plant_settings.carrot,
-            ["garlic"] = cucina_vegana.plant_settings.garlic,
-            ["chili"] = cucina_vegana.plant_settings.chili,
-            ["onion"] = cucina_vegana.plant_settings.onion,
-            ["cucumber"] = cucina_vegana.plant_settings.cucumber,
-            ["strawberry"] = cucina_vegana.plant_settings.strawberry,
-			["corn"] = cucina_vegana.plant_settings.corn
-		}
+	["asparagus"] = cucina_vegana.plant_settings.asparagus,
+	["chives"] = cucina_vegana.plant_settings.chives,
+	["flax"] = cucina_vegana.plant_settings.flax,
+	["kohlrabi"] = cucina_vegana.plant_settings.kohlrabi,
+	["lettuce"] = cucina_vegana.plant_settings.lettuce,
+	["parsley"] = cucina_vegana.plant_settings.parsley,
+    ["peanut"] = cucina_vegana.plant_settings.peanut,
+    ["rosemary"] = cucina_vegana.plant_settings.rosemary,
+	["rice"] = cucina_vegana.plant_settings.rice,
+	["soy"] = cucina_vegana.plant_settings.soy,
+	["sunflower"] = cucina_vegana.plant_settings.sunflower,
+    ["banana"] = cucina_vegana.plant_settings.banana,
+    ["tomato"] = cucina_vegana.plant_settings.tomato,
+    ["potato"] = cucina_vegana.plant_settings.potato,
+    ["carrot"] = cucina_vegana.plant_settings.carrot,
+    ["garlic"] = cucina_vegana.plant_settings.garlic,
+    ["chili"] = cucina_vegana.plant_settings.chili,
+    ["onion"] = cucina_vegana.plant_settings.onion,
+    ["cucumber"] = cucina_vegana.plant_settings.cucumber,
+    ["strawberry"] = cucina_vegana.plant_settings.strawberry,
+	["corn"] = cucina_vegana.plant_settings.corn
+}
 
 for pname, value in pairs(plants) do
-
-	if(value) then
+	if value then
 		local n_default = modname .. ":seed_" .. pname
 		local n_redo    = modname .. ":" .. pname .. "_seed"
-        -- Load all flowers in default-mode
-			dofile(modpath .. "/" .. pname .. ".lua")
-			dofile(modpath .. "/".. pname .. ".lua")
-			core.register_alias(n_redo, n_default)
 
-	end -- if(value)
+        -- Load all flowers in default-mode
+		dofile(modpath .. "/" .. pname .. ".lua")
+
+		core.register_alias(n_redo, n_default)
+	end
 
     core.log("info", "[MOD] " .. modname .. " Module: " .. pname .. " loaded.")
-
-end -- for
+end
 
 local shrubs = {
-				["vine"] = cucina_vegana.shrub_settings.vine,
-				["coffee"] = cucina_vegana.shrub_settings.coffee
-			}
+	["vine"] = cucina_vegana.shrub_settings.vine,
+	["coffee"] = cucina_vegana.shrub_settings.coffee
+}
 
 for sname, value in pairs(shrubs) do
-	if(value) then
+	if value then
 		dofile(modpath .. "/" .. sname .. "_def.lua")
 		dofile(modpath .. "/" .. sname .. ".lua")
 	    core.log("info", "[MOD] " .. modname .. " Module: " .. sname .. " loaded.")
-	end -- if(value)
-
-
-end -- for shrub,
+	end
+end
 
 -- Insert Recipes
 dofile(modpath .. "/overrides.lua")
@@ -136,10 +133,5 @@ dofile(modpath .. "/recipes_support.lua")
 dofile(modpath .. "/recipes_5xx.lua") -- New recipes with MT 5.0
 dofile(modpath .. "/register_mods.lua")
 dofile(modpath .. "/aliases.lua")
-
-if(core.get_modpath("bonemeal")) then
-    bonemeal:add_crop(cucina_vegana.plant_settings.bonemeal_list)
-
-end -- if(cucina_vegana.plant_settings.bonemeal
 
 core.log("info", "[MOD] " .. modname .. " Version " .. cucina_vegana.version .. " loaded.")

--- a/kohlrabi.lua
+++ b/kohlrabi.lua
@@ -28,23 +28,25 @@ core.register_node("cucina_vegana:wild_" .. pname, {
 	paramtype = "light",
 	walkable = false,
 	drop = {
-			items = {
-					{items = {"cucina_vegana:seed_" .. pname .. " 3"}},
-					{items = {"cucina_vegana:" .. pname}},
-				}
-			},
+		items = {
+			{items = {"cucina_vegana:seed_" .. pname .. " 3"}},
+			{items = {"cucina_vegana:" .. pname}},
+		}
+	},
 	drawtype = "plantlike",
 	paramtype2 = "facedir",
 	tiles = {"cucina_vegana_" .. pname .. "_" .. step .. ".png"},
 	sunlight_propagates = true,
-	groups = {snappy = 3, dig_immediate=1, flammable=2, plant=1, attached_node = 1,
-                growing = 1, not_in_creative_inventory = 1},
+	groups = {
+		snappy = 3, dig_immediate = 1, flammable = 2, plant = 1,
+		attached_node = 1, growing = 1, not_in_creative_inventory = 1
+	},
 	sounds = default.node_sound_leaves_defaults(),
 	selection_box = {
-			type = "fixed",
-			fixed = {
-				{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
-			},
+		type = "fixed",
+		fixed = {
+			{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
+		},
 	},
 })
 
@@ -52,22 +54,23 @@ core.register_alias("kohlrabi:kohlrabi", "cucina_vegana:" .. pname)
 core.register_alias("kohlrabi:seed", "cucina_vegana:" .. pname .. "_seed")
 core.register_alias("kohlrabi:wild_kohlrabi", "cucina_vegana:wild_" .. pname)
 
-if(cucina_vegana.plant_settings.bonemeal) then
-    table.insert(cucina_vegana.plant_settings.bonemeal_list,
-                 {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:seed_" .. pname})
-
-end -- if(cucina_vegana.plant_settings.bonemeal
+if cucina_vegana.plant_settings.bonemeal then
+	local table = {
+		"cucina_vegana:" .. pname .. "_",
+		step,
+		"cucina_vegana:seed_" .. pname
+	}
+    table.insert(cucina_vegana.plant_settings.bonemeal_list, table)
+end
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then
     cucina_vegana.register_farming_ng(pname, step)
-
-end -- if(cucina_vegana.farming_ng
+end
 
 -- Register @ Signs_bot
-if(cucina_vegana.signs_bot) then
-        cucina_vegana.register_signs_bot(pname, 1, step)
-
+if cucina_vegana.signs_bot then
+    cucina_vegana.register_signs_bot(pname, 1, step)
 end
 
 core.register_decoration({

--- a/lettuce.lua
+++ b/lettuce.lua
@@ -28,23 +28,25 @@ core.register_node("cucina_vegana:wild_" .. pname, {
 	paramtype = "light",
 	walkable = false,
 	drop = {
-			items = {
-					{items = {"cucina_vegana:seed_" .. pname .. " 3"}},
-					{items = {"cucina_vegana:" .. pname}},
-				}
-			},
+		items = {
+			{items = {"cucina_vegana:seed_" .. pname .. " 3"}},
+			{items = {"cucina_vegana:" .. pname}},
+		}
+	},
 	drawtype = "plantlike",
 	paramtype2 = "facedir",
 	tiles = {"cucina_vegana_" .. pname .. "_5.png"},
 	sunlight_propagates = true,
-	groups = {snappy = 3, dig_immediate=1, flammable=2, plant=1, attached_node = 1,
-                growing = 1, not_in_creative_inventory = 1},
+	groups = {
+		snappy = 3, dig_immediate = 1, flammable = 2, plant = 1,
+		attached_node = 1, growing = 1, not_in_creative_inventory = 1
+	},
 	sounds = default.node_sound_leaves_defaults(),
 	selection_box = {
-			type = "fixed",
-			fixed = {
-				{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
-			},
+		type = "fixed",
+		fixed = {
+			{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
+		},
 	},
 })
 
@@ -55,22 +57,23 @@ core.register_alias("lettuce:lettuce", "cucina_vegana:" .. pname)
 core.register_alias("lettuce:seed", "cucina_vegana:" .. pname .. "_seed")
 core.register_alias("lettuce:wild_lettuce", "cucina_vegana:wild_" .. pname)
 
-if(cucina_vegana.plant_settings.bonemeal) then
-    table.insert(cucina_vegana.plant_settings.bonemeal_list,
-                 {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:seed_" .. pname})
-
-end -- if(cucina_vegana.plant_settings.bonemeal
+if cucina_vegana.plant_settings.bonemeal then
+	local table = {
+		"cucina_vegana:" .. pname .. "_",
+		step,
+		"cucina_vegana:seed_" .. pname
+	}
+    table.insert(cucina_vegana.plant_settings.bonemeal_list, table)
+end
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then
     cucina_vegana.register_farming_ng(pname, step)
-
-end -- if(cucina_vegana.farming_ng
+end
 
 -- Register @ Signs_bot
-if(cucina_vegana.signs_bot) then
-        cucina_vegana.register_signs_bot(pname, 1, step)
-
+if cucina_vegana.signs_bot then
+    cucina_vegana.register_signs_bot(pname, 1, step)
 end
 
 core.register_decoration({

--- a/lib.lua
+++ b/lib.lua
@@ -12,115 +12,93 @@ math.randomseed(os.time())
 function cv.lib.register_bottom_abm(node, nextnode, duration, light)
     local percent = 1
 
-    if(core.registered_nodes[node]) then
+    if core.registered_nodes[node] then
         core.register_abm({
             nodenames = {node},
             interval = duration,
             chance = percent,
             catch_up = true,
             action = function(pos, node, active_object_count, active_object_count_wider)
-                        local nodepos = pos
-                        if(cv.lib.check_soil(nodepos)) then
-                            if(cv.lib.check_light(nodepos, light)) then
-                                core.set_node(nodepos, {name = nextnode})
-
-                            end -- if(cv.check_light
-
-                        end -- if(cv.lib.check_soil)
-
-                    end, -- function(
-
-        }) -- core.register_abm({
-
-    end -- if(nodename ~= nil
-
+                local nodepos = pos
+                if cv.lib.check_soil(nodepos) then
+                    if cv.lib.check_light(nodepos, light) then
+                        core.set_node(nodepos, {name = nextnode})
+                    end
+                end
+            end,
+        })
+    end
 end
 
 function cv.lib.register_top_abm(node, nextnode, duration, light)
     local percent = 1
 
-    if(core.registered_nodes[node]) then
+    if core.registered_nodes[node] then
         core.register_abm({
             nodenames = {node},
             interval = duration,
             chance = percent,
             catch_up = true,
             action = function(pos, node, active_object_count, active_object_count_wider)
-                        local nodepos = pos
-                            if(cv.lib.check_light(nodepos, light)) then
-                                core.set_node(nodepos, {name = nextnode})
-
-                            end -- if(cv.check_light
-
-                    end, -- function(
-
-        }) -- core.register_abm({
-
-    end -- if(nodename ~= nil
-
+                local nodepos = pos
+                if cv.lib.check_light(nodepos, light) then
+                    core.set_node(nodepos, {name = nextnode})
+                end
+            end,
+        })
+    end
 end
 
 function cv.lib.check_light(pos, level)
     local node = core.get_node_or_nil(pos)
 
-    if(node) then
+    if node then
         local light = core.get_node_light(pos) or 0
-        if(light >= level) then return true end
-
-    end -- if(core.get_node_or_nil(
+        if light >= level then
+            return true
+        end
+    end
 
     return false
-
-end -- function aqua_farming.check_light
+end
 
 function cv.lib.check_soil(pos)
     local below = {x = pos.x, y = pos.y - 1, z = pos.z}
     local soil = core.get_node_or_nil(below)
 
-    if(soil and core.get_item_group(soil, "group:soil")) then
+    if soil and core.get_item_group(soil, "group:soil") then
         return true
-
-    end -- if(core.get_node_or_nil(
-
-    return false
-
-end -- cv.lib.check_soil
-
-function cv.lib.check_air(pos)
-    local air = core.get_node_or_nil(pos)
-    if (air) and (string.match(air.name,"air")) then
-        return true
-
     end
 
     return false
+end
 
-end -- cv.lib.check_air
+function cv.lib.check_air(pos)
+    local air = core.get_node_or_nil(pos)
+    if air and string.match(air.name, "air") then
+        return true
+    end
 
-function cv.lib.coffee_effect(playerobject)
-    if(not playerobject) then return end
+    return false
+end
 
-    local playername = playerobject:get_player_name()
-    local seconds = cv.settings.coffee_effect_duration
-    local highspeed = cv.settings.coffee_effect_speed
+function cv.lib.coffee_effect(player)
+    if not player then return end
+
+    local playername  = player:get_player_name()
+    local seconds     = cv.settings.coffee_effect_duration
+    local highspeed   = cv.settings.coffee_effect_speed
     local normalspeed = 1
 
-    playerobject:set_physics_override({speed = highspeed})
+    player:set_physics_override({speed = highspeed})
     core.chat_send_player(playername, S("Coffeespeed. @1 Seconds left.", seconds))
 
-    core.after(seconds/2, function()
-                                    local playerobject = core.get_player_by_name(playername)
-                                    if(not playerobject) then return end
-
-                                    core.chat_send_player(playername,S("@1 Seconds left.", seconds/2))
-                              end, playername)
+    core.after(seconds / 2, function()
+        core.chat_send_player(playername, S("@1 Seconds left.", seconds / 2))
+    end)
 
     core.after(seconds, function()
-                                    local playerobject = core.get_player_by_name(playername)
-                                    if(not playerobject) then return end
-
-                                    core.chat_send_player(playername,S("You move normal again."))
-                                    playerobject:set_physics_override({speed = normalspeed})
-                           end, playername)
-
+        core.chat_send_player(playername, S("You move normal again."))
+        player:set_physics_override({speed = normalspeed})
+    end)
 end

--- a/nodes.lua
+++ b/nodes.lua
@@ -154,9 +154,7 @@ core.register_node("cucina_vegana:coffee_cup", {
 	description = S("Cup of Coffee cold"),
 	drawtype = "mesh",
 	mesh = "cucina_vegana_coffee_cup.obj",
-	tiles = {
-				"cucina_vegana_coffee_cup.png",
-			},
+	tiles = {"cucina_vegana_coffee_cup.png"},
 	inventory_image = "cucina_vegana_coffee_cup_inv.png",
 	wield_image = "cucina_vegana_coffee_cup_inv.png",
 	paramtype = "light",
@@ -177,35 +175,31 @@ core.register_node("cucina_vegana:coffee_cup_hot", {
 	drawtype = "mesh",
 	mesh = "cucina_vegana_coffee_cup.obj",
 	tiles = {
-				{
-					name = "cucina_vegana_coffee_cup_hot_anim.png",
-					backfaceculling = false,
-					animation =
-					{
-						type = "vertical_frames",
-						aspect_w = 64,
-						aspect_h = 64,
-						length = 3
-
-					}
-
-				}
-
-			},
+		{
+			name = "cucina_vegana_coffee_cup_hot_anim.png",
+			backfaceculling = false,
+			animation = {
+				type = "vertical_frames",
+				aspect_w = 64,
+				aspect_h = 64,
+				length = 3
+			}
+		}
+	},
 	inventory_image = "cucina_vegana_coffee_cup_hot_inv.png",
 	wield_image = "cucina_vegana_coffee_cup_hot_inv.png",
 	paramtype = "light",
 	paramtype2 = "facedir",
 	param2 = "4dir",
 	is_ground_content = false,
-	on_use = function(itemstack, playerobject, pointed_thing)
-				if (not playerobject) then return end
+	on_use = function(itemstack, player, pointed_thing)
+		if not player then return end
 
-				core.item_eat(2)
-				cv.lib.coffee_effect(playerobject)
-				itemstack:take_item(1)
-				return itemstack
-			end,
+		core.item_eat(2)
+		cv.lib.coffee_effect(player)
+		itemstack:take_item(1)
+		return itemstack
+	end,
 	walkable = true,
 	selection_box = {
 		type = "fixed",

--- a/onion.lua
+++ b/onion.lua
@@ -28,44 +28,47 @@ core.register_node("cucina_vegana:wild_" .. pname, {
 	paramtype = "light",
 	walkable = false,
 	drop = {
-			items = {
-					{items = {"cucina_vegana:seed_" .. pname .. " 4"}},
-					{items = {"cucina_vegana:" .. pname .. " 2"}},
-				}
-			},
+		items = {
+			{items = {"cucina_vegana:seed_" .. pname .. " 4"}},
+			{items = {"cucina_vegana:" .. pname .. " 2"}},
+		}
+	},
 	drawtype = "plantlike",
 	paramtype2 = "facedir",
 	sunlight_propagates = true,
 	tiles = {"cucina_vegana_" .. pname .. "_" .. step .. ".png"},
-	groups = {snappy = 3, dig_immediate=1, flammable=2, plant=1, attached_node = 1,
-                growing = 1, not_in_creative_inventory = 1},
+	groups = {
+		snappy = 3, dig_immediate=1, flammable=2, plant=1,
+		attached_node = 1, growing = 1, not_in_creative_inventory = 1
+	},
 	sounds = default.node_sound_leaves_defaults(),
 	selection_box = {
-			type = "fixed",
-			fixed = {
-				{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
-			},
+		type = "fixed",
+		fixed = {
+			{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
+		},
 	},
 })
 
 cucina_vegana.add_group("cucina_vegana:seed_" .. pname, {seed_onion = 1})
 
-if(cucina_vegana.plant_settings.bonemeal) then
-    table.insert(cucina_vegana.plant_settings.bonemeal_list,
-                 {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:seed_" .. pname})
-
-end -- if(cucina_vegana.plant_settings.bonemeal
+if cucina_vegana.plant_settings.bonemeal then
+	local table = {
+		"cucina_vegana:" .. pname .. "_",
+		step,
+		"cucina_vegana:seed_" .. pname
+	}
+    table.insert(cucina_vegana.plant_settings.bonemeal_list, table)
+end
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then
     cucina_vegana.register_farming_ng(pname, step)
-
-end -- if(cucina_vegana.farming_ng
+end
 
 -- Register @ Signs_bot
-if(cucina_vegana.signs_bot) then
+if cucina_vegana.signs_bot then
     cucina_vegana.register_signs_bot(pname, 1, step)
-
 end
 
 core.register_decoration({

--- a/overrides.lua
+++ b/overrides.lua
@@ -1,56 +1,41 @@
 local modname = core.get_current_modname()
 
-if(core.registered_items["bees:bottle_honey"] ~= nil) then
+if core.registered_items["bees:bottle_honey"] ~= nil then
     cucina_vegana.add_group("bees:bottle_honey", {food = 1, food_honey = 1})
-    print("[MOD] " .. modname .. " Group changed on \"bees:bottle_honey\".")
     core.log("info", "[MOD] " .. modname .. " Group changed on \"bees:bottle_honey\".")
-
 end
 
-if(core.registered_items["farming:bread"] ~= nil) then
-    cucina_vegana.add_group("farming:bread",{food_bread = 1})
-    print("[MOD] " .. modname .. " Group changed on \"farming:bread\".")
+if core.registered_items["farming:bread"] ~= nil then
+    cucina_vegana.add_group("farming:bread", {food_bread = 1})
     core.log("info", "[MOD] " .. modname .. " Group changed on \"farming:bread\".")
-
 end
 
-if(core.registered_items["farming:bread_slice"] ~= nil) then
-    cucina_vegana.add_group("farming:bread_slice",{food_bread = 1})
-    print("[MOD] " .. modname .. " Group changed on \"farming:bread_slice\".")
+if core.registered_items["farming:bread_slice"] ~= nil then
+    cucina_vegana.add_group("farming:bread_slice", {food_bread = 1})
     core.log("info", "[MOD] " .. modname .. " Group changed on \"farming:bread_slice\".")
-
 end
 
-if(core.registered_items["farming:pumpkin_bread"] ~= nil) then
+if core.registered_items["farming:pumpkin_bread"] ~= nil then
     cucina_vegana.add_group("farming:pumpkin_bread", {food_bread = 1})
-    print("[MOD] " .. modname .. " Group changed on \"farming:pumpkin_bread\".")
     core.log("info", "[MOD] " .. modname .. " Group changed on \"farming:pumpkin_bread\".")
 end
 
-if(core.registered_items["farming_food:corn_bread"] ~= nil) then
-    cucina_vegana.add_group("farming_food:corn_bread",{food_bread = 1})
-    print("[MOD] " .. modname .. " Group changed on \"farming_food:corn_bread\".")
+if core.registered_items["farming_food:corn_bread"] ~= nil then
+    cucina_vegana.add_group("farming_food:corn_bread", {food_bread = 1})
     core.log("info", "[MOD] " .. modname .. " Group changed on \"farming_food:corn_bread\".")
-
 end
 
-if(core.registered_items["farming:rice_bread"] ~= nil) then
+if core.registered_items["farming:rice_bread"] ~= nil then
     cucina_vegana.add_group("farming:rice_bread", {food = 1, food_bread = 1})
-    print("[MOD] " .. modname .. " Group changed on \"farming:rice_bread\".")
     core.log("info", "[MOD] " .. modname .. " Group changed on \"farming:rice_bread\".")
-
 end
 
-if(core.registered_items["farming:rice"] ~= nil) then
+if core.registered_items["farming:rice"] ~= nil then
     cucina_vegana.add_group("farming:rice", {food = 1, food_rice = 1})
-    print("[MOD] " .. modname .. " Group changed on \"farming:rice\".")
     core.log("info", "[MOD] " .. modname .. " Group changed on \"farming:rice\".")
-
 end
 
-if(core.registered_items["farming:rice_flour"] ~= nil) then
+if core.registered_items["farming:rice_flour"] ~= nil then
     cucina_vegana.add_group("farming:rice_flour", {food = 1, food_flour = 1})
-    print("[MOD] " .. modname .. " Group changed on \"farming:rice_flour\".")
     core.log("info", "[MOD] " .. modname .. " Group changed on \"farming:rice_flour\".")
-
 end

--- a/parsley.lua
+++ b/parsley.lua
@@ -28,23 +28,25 @@ core.register_node("cucina_vegana:wild_" .. pname, {
 	paramtype = "light",
 	walkable = false,
 	drop = {
-			items = {
-					{items = {"cucina_vegana:seed_" .. pname .. " 3"}},
-					{items = {"cucina_vegana:" .. pname}},
-				}
-			},
+		items = {
+			{items = {"cucina_vegana:seed_" .. pname .. " 3"}},
+			{items = {"cucina_vegana:" .. pname}},
+		}
+	},
 	drawtype = "plantlike",
 	paramtype2 = "facedir",
 	tiles = {"cucina_vegana_" .. pname .. "_" .. step .. ".png"},
 	sunlight_propagates = true,
-	groups = {snappy = 3, dig_immediate=1, flammable=2, plant=1, attached_node = 1,
-                growing = 1, not_in_creative_inventory = 1},
+	groups = {
+		snappy = 3, dig_immediate = 1, flammable = 2, plant = 1,
+		attached_node = 1, growing = 1, not_in_creative_inventory = 1
+	},
 	sounds = default.node_sound_leaves_defaults(),
 	selection_box = {
-			type = "fixed",
-			fixed = {
-				{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
-			},
+		type = "fixed",
+		fixed = {
+			{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
+		},
 	},
 })
 
@@ -52,22 +54,23 @@ core.register_alias("parsley:parsley", "cucina_vegana:" .. pname)
 core.register_alias("parsley:seed", "cucina_vegana:" .. pname .. "_seed")
 core.register_alias("parsley:wild_parsley", "cucina_vegana:wild_" .. pname)
 
-if(cucina_vegana.plant_settings.bonemeal) then
-    table.insert(cucina_vegana.plant_settings.bonemeal_list,
-                 {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:seed_" .. pname})
-
-end -- if(cucina_vegana.plant_settings.bonemeal
+if cucina_vegana.plant_settings.bonemeal then
+	local table = {
+		"cucina_vegana:" .. pname .. "_",
+		step,
+		"cucina_vegana:seed_" .. pname
+	}
+    table.insert(cucina_vegana.plant_settings.bonemeal_list, table)
+end
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then
     cucina_vegana.register_farming_ng(pname, step)
-
-end -- if(cucina_vegana.farming_ng
+end
 
 -- Register @ Signs_bot
-if(cucina_vegana.signs_bot) then
-        cucina_vegana.register_signs_bot(pname, 1, step)
-
+if cucina_vegana.signs_bot then
+    cucina_vegana.register_signs_bot(pname, 1, step)
 end
 
 core.register_decoration({

--- a/peanut.lua
+++ b/peanut.lua
@@ -28,43 +28,46 @@ core.register_node("cucina_vegana:wild_" .. pname, {
 	paramtype = "light",
 	walkable = false,
 	drop = {
-			items = {
-					{items = {"cucina_vegana:seed_" .. pname .. " 4"}},
-				}
-			},
+		items = {
+			{items = {"cucina_vegana:seed_" .. pname .. " 4"}},
+		}
+	},
 	drawtype = "plantlike",
 	paramtype2 = "facedir",
 	sunlight_propagates = true,
 	tiles = {"cucina_vegana_" .. pname .. "_" .. step .. ".png"},
-	groups = {snappy = 3, dig_immediate=1, flammable=2, plant=1, attached_node = 1,
-                growing = 1, not_in_creative_inventory = 1},
+	groups = {
+		snappy = 3, dig_immediate = 1, flammable = 2, plant = 1,
+		attached_node = 1, growing = 1, not_in_creative_inventory = 1
+	},
 	sounds = default.node_sound_leaves_defaults(),
 	selection_box = {
-			type = "fixed",
-			fixed = {
-				{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
-			},
+		type = "fixed",
+		fixed = {
+			{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
+		},
 	},
 })
 
 cucina_vegana.add_group("cucina_vegana:seed_" .. pname, {seed_peanut = 1})
 
-if(cucina_vegana.plant_settings.bonemeal) then
-    table.insert(cucina_vegana.plant_settings.bonemeal_list,
-                 {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:seed_" .. pname})
-
-end -- if(cucina_vegana.plant_settings.bonemeal
+if cucina_vegana.plant_settings.bonemeal then
+	local table = {
+		"cucina_vegana:" .. pname .. "_",
+		step,
+		"cucina_vegana:seed_" .. pname
+	}
+    table.insert(cucina_vegana.plant_settings.bonemeal_list, table)
+end
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then
     cucina_vegana.register_farming_ng(pname, step)
-
-end -- if(cucina_vegana.farming_ng
+end
 
 -- Register @ Signs_bot
-if(cucina_vegana.signs_bot) then
+if cucina_vegana.signs_bot then
     cucina_vegana.register_signs_bot(pname, 1, step)
-
 end
 
 core.register_decoration({

--- a/potato.lua
+++ b/potato.lua
@@ -28,44 +28,47 @@ core.register_node("cucina_vegana:wild_" .. pname, {
 	paramtype = "light",
 	walkable = false,
 	drop = {
-			items = {
-					{items = {"cucina_vegana:seed_" .. pname .. " 4"}},
-					{items = {"cucina_vegana:" .. pname .. " 3"}},
-				}
-			},
+		items = {
+			{items = {"cucina_vegana:seed_" .. pname .. " 4"}},
+			{items = {"cucina_vegana:" .. pname .. " 3"}},
+		}
+	},
 	drawtype = "plantlike",
 	paramtype2 = "facedir",
 	sunlight_propagates = true,
 	tiles = {"cucina_vegana_" .. pname .. "_" .. step .. ".png"},
-	groups = {snappy = 3, dig_immediate=1, flammable=2, plant=1, attached_node = 1,
-                growing = 1, not_in_creative_inventory = 1},
+	groups = {
+		snappy = 3, dig_immediate = 1, flammable = 2, plant = 1,
+		attached_node = 1, growing = 1, not_in_creative_inventory = 1
+	},
 	sounds = default.node_sound_leaves_defaults(),
 	selection_box = {
-			type = "fixed",
-			fixed = {
-				{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
-			},
+		type = "fixed",
+		fixed = {
+			{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
+		},
 	},
 })
 
 cucina_vegana.add_group("cucina_vegana:seed_" .. pname, {seed_potato = 1})
 
-if(cucina_vegana.plant_settings.bonemeal) then
-    table.insert(cucina_vegana.plant_settings.bonemeal_list,
-                 {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:seed_" .. pname})
-
-end -- if(cucina_vegana.plant_settings.bonemeal
+if cucina_vegana.plant_settings.bonemeal then
+	local table = {
+		"cucina_vegana:" .. pname .. "_",
+		step,
+		"cucina_vegana:seed_" .. pname
+	}
+    table.insert(cucina_vegana.plant_settings.bonemeal_list, table)
+end
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then
     cucina_vegana.register_farming_ng(pname, step)
-
-end -- if(cucina_vegana.farming_ng
+end
 
 -- Register @ Signs_bot
-if(cucina_vegana.signs_bot) then
-        cucina_vegana.register_signs_bot(pname, 1, step)
-
+if cucina_vegana.signs_bot then
+    cucina_vegana.register_signs_bot(pname, 1, step)
 end
 
 core.register_decoration({

--- a/recipes.lua
+++ b/recipes.lua
@@ -8,372 +8,397 @@
 
 core.register_craft({
 	output = "cucina_vegana:blueberry_pot",
-	recipe = {	{"group:food_sugar", "default:stick", "group:food_sugar"},
-				{"cucina_vegana:blueberry_puree", "cucina_vegana:blueberry_puree", "cucina_vegana:blueberry_puree"},
-                {"", "bucket:bucket_water", ""}
-			},
+	recipe = {
+		{"group:food_sugar", "default:stick", "group:food_sugar"},
+		{"cucina_vegana:blueberry_puree", "cucina_vegana:blueberry_puree", "cucina_vegana:blueberry_puree"},
+        {"", "bucket:bucket_water", ""}
+	},
     replacements = {
-                    {"default:stick", "default:stick"}
-                   }
+        {"default:stick", "default:stick"}
+    }
 })
 
 core.register_craft({
 	output = "cucina_vegana:blueberry_pot",
-	recipe = {	{"group:food_sugar", "default:stick", "group:food_sugar"},
-				{"cucina_vegana:blueberry_puree", "cucina_vegana:blueberry_puree", "cucina_vegana:blueberry_puree"},
-                {"", "bucket:bucket_river_water", ""}
-			},
+	recipe = {
+		{"group:food_sugar", "default:stick", "group:food_sugar"},
+		{"cucina_vegana:blueberry_puree", "cucina_vegana:blueberry_puree", "cucina_vegana:blueberry_puree"},
+        {"", "bucket:bucket_river_water", ""}
+	},
     replacements = {
-                    {"default:stick", "default:stick"}
-                   }
+        {"default:stick", "default:stick"}
+    }
 })
 
 core.register_craft({
 	output = "cucina_vegana:blueberry_pot",
-	recipe = {	{"cucina_vegana:molasses", "default:stick", "cucina_vegana:molasses"},
-				{"cucina_vegana:blueberry_puree", "cucina_vegana:blueberry_puree", "cucina_vegana:blueberry_puree"},
-                {"", "bucket:bucket_water", ""}
-			},
+	recipe = {
+		{"cucina_vegana:molasses", "default:stick", "cucina_vegana:molasses"},
+		{"cucina_vegana:blueberry_puree", "cucina_vegana:blueberry_puree", "cucina_vegana:blueberry_puree"},
+        {"", "bucket:bucket_water", ""}
+	},
     replacements = {
-                        {"default:stick", "default:stick"},
-                        {"cucina_vegana:molasses", "vessels:drinking_glass 2"}
-                   }
+        {"default:stick", "default:stick"},
+        {"cucina_vegana:molasses", "vessels:drinking_glass 2"}
+    }
 })
 
 core.register_craft({
 	output = "cucina_vegana:blueberry_pot",
-	recipe = {	{"cucina_vegana:molasses", "default:stick", "cucina_vegana:molasses"},
-				{"cucina_vegana:blueberry_puree", "cucina_vegana:blueberry_puree", "cucina_vegana:blueberry_puree"},
-                {"", "bucket:bucket_river_water", ""}
-			},
+	recipe = {
+		{"cucina_vegana:molasses", "default:stick", "cucina_vegana:molasses"},
+		{"cucina_vegana:blueberry_puree", "cucina_vegana:blueberry_puree", "cucina_vegana:blueberry_puree"},
+        {"", "bucket:bucket_river_water", ""}
+	},
     replacements = {
-                        {"default:stick", "default:stick"},
-                        {"cucina_vegana:molasses", "vessels:drinking_glass 2"}
-                   }
+        {"default:stick", "default:stick"},
+        {"cucina_vegana:molasses", "vessels:drinking_glass 2"}
+    }
 })
 
 core.register_craft({
 	output = "cucina_vegana:bowl 5",
-	recipe = {	{"default:glass", "", "default:glass"},
-				{"default:glass", "default:glass", "default:glass"},
-             }
+	recipe = {
+		{"default:glass", "", "default:glass"},
+		{"default:glass", "default:glass", "default:glass"},
+    }
 })
 
 core.register_craft({
 	output = "cucina_vegana:bread_garlic",
-	recipe = {	{"group:food_flour", "cucina_vegana:sunflower_seeds_oil", ""},
-				{"cucina_vegana:rosemary", "cucina_vegana:garlic", ""}
-			},
+	recipe = {
+		{"group:food_flour", "cucina_vegana:sunflower_seeds_oil", ""},
+		{"cucina_vegana:rosemary", "cucina_vegana:garlic", ""}
+	},
     replacements = {
-                        {"cucina_vegana:sunflower_seeds_oil", "vessels:glass_bottle"},
-                    }
+        {"cucina_vegana:sunflower_seeds_oil", "vessels:glass_bottle"},
+    }
 })
 core.register_craft({
 	output = "cucina_vegana:ciabatta_dough",
-	recipe = {	{"cucina_vegana:soy_milk", "cucina_vegana:sunflower_seeds_oil", ""},
-				{"group:food_flour", "cucina_vegana:rosemary", ""}
-			},
+	recipe = {
+		{"cucina_vegana:soy_milk", "cucina_vegana:sunflower_seeds_oil", ""},
+		{"group:food_flour", "cucina_vegana:rosemary", ""}
+	},
     replacements = {
-                        {"cucina_vegana:soy_milk", "vessels:drinking_glass"},
-                        {"cucina_vegana:sunflower_seeds_oil", "vessels:glass_bottle"},
-                    }
+        {"cucina_vegana:soy_milk", "vessels:drinking_glass"},
+        {"cucina_vegana:sunflower_seeds_oil", "vessels:glass_bottle"},
+    }
 })
 
 core.register_craft({
 	output = "cucina_vegana:coffe_cup 4",
-	recipe = {	{"cucina_vegana:coffee_powder", "bucket:bucket_water", "default:paper"},
-				{"group:food_milk", "cucina_vegana:coffee_powder", ""}
-			},
+	recipe = {
+		{"cucina_vegana:coffee_powder", "bucket:bucket_water", "default:paper"},
+		{"group:food_milk", "cucina_vegana:coffee_powder", ""}
+	},
     replacements = {
-                        {"group:food_milk", "vessels:drinking_glass"},
-                        {"bucket:bucket_water", "bucket:bucket_empty"},
-                    }
+        {"group:food_milk", "vessels:drinking_glass"},
+        {"bucket:bucket_water", "bucket:bucket_empty"},
+    }
 })
 
 core.register_craft({
 	output = "cucina_vegana:coffee_cup 4",
-	recipe = {	{"cucina_vegana:coffee_powder", "bucket:bucket_river_water", "default:paper"},
-				{"group:food_milk", "cucina_vegana:coffee_powder", ""}
-			},
+	recipe = {
+		{"cucina_vegana:coffee_powder", "bucket:bucket_river_water", "default:paper"},
+		{"group:food_milk", "cucina_vegana:coffee_powder", ""}
+	},
     replacements = {
-                        {"group:food_milk", "vessels:drinking_glass"},
-                        {"bucket:bucket_river_water", "bucket:bucket_empty"},
-                    }
+        {"group:food_milk", "vessels:drinking_glass"},
+        {"bucket:bucket_river_water", "bucket:bucket_empty"},
+    }
 })
 
 core.register_craft({
 	output = "cucina_vegana:coffee_powder",
-	recipe = {	{"group:stone", "cucina_vegana:coffee_beans_roasted", "group:stone"},
-				{"group:stone", "cucina_vegana:coffee_beans_roasted", "group:stone"}
-			},
+	recipe = {
+		{"group:stone", "cucina_vegana:coffee_beans_roasted", "group:stone"},
+		{"group:stone", "cucina_vegana:coffee_beans_roasted", "group:stone"}
+	},
     replacements = {
-                        {"group:stone", "default:stone"},
-                    }
+        {"group:stone", "default:stone"},
+    }
 })
 
 core.register_craft({
 	output = "cucina_vegana:dandelion_suds",
-	recipe = {	{"flowers:dandelion_yellow", "flowers:dandelion_yellow", "flowers:dandelion_yellow"},
-				{"flowers:dandelion_yellow", "flowers:dandelion_yellow", "flowers:dandelion_yellow"},
-                {"", "bucket:bucket_water", ""}
-			}
+	recipe = {
+		{"flowers:dandelion_yellow", "flowers:dandelion_yellow", "flowers:dandelion_yellow"},
+		{"flowers:dandelion_yellow", "flowers:dandelion_yellow", "flowers:dandelion_yellow"},
+        {"", "bucket:bucket_water", ""}
+	}
 })
 
 core.register_craft({
 	output = "cucina_vegana:dandelion_suds",
-	recipe = {	{"flowers:dandelion_yellow", "flowers:dandelion_yellow", "flowers:dandelion_yellow"},
-				{"flowers:dandelion_yellow", "flowers:dandelion_yellow", "flowers:dandelion_yellow"},
-                {"", "bucket:bucket_river_water", ""}
-			}
+	recipe = {
+		{"flowers:dandelion_yellow", "flowers:dandelion_yellow", "flowers:dandelion_yellow"},
+		{"flowers:dandelion_yellow", "flowers:dandelion_yellow", "flowers:dandelion_yellow"},
+        {"", "bucket:bucket_river_water", ""}
+	}
 })
 
 core.register_craft({
 	output = "cucina_vegana:flax_seed_oil",
-	recipe = {	{"group:seed_flax", "group:seed_flax", "group:seed_flax"},
-				{"group:seed_flax", "group:seed_flax", "group:seed_flax"},
-				{"", "vessels:glass_bottle", ""}
-			}
+	recipe = {
+		{"group:seed_flax", "group:seed_flax", "group:seed_flax"},
+		{"group:seed_flax", "group:seed_flax", "group:seed_flax"},
+		{"", "vessels:glass_bottle", ""}
+	}
 })
 
 core.register_craft({
 	output = "cucina_vegana:lettuce_oil",
-	recipe = {	{"group:seed_lettuce", "group:seed_lettuce", "group:seed_lettuce"},
-				{"group:seed_lettuce", "group:seed_lettuce", "group:seed_lettuce"},
-				{"", "vessels:glass_bottle", ""}
-			}
+	recipe = {
+		{"group:seed_lettuce", "group:seed_lettuce", "group:seed_lettuce"},
+		{"group:seed_lettuce", "group:seed_lettuce", "group:seed_lettuce"},
+		{"", "vessels:glass_bottle", ""}
+	}
 })
 
 core.register_craft({
 	output = "cucina_vegana:peanut_oil",
-	recipe = {	{"group:seed_peanut", "group:seed_peanut", "group:seed_peanut"},
-				{"group:seed_peanut", "group:seed_peanut", "group:seed_peanut"},
-				{"", "vessels:glass_bottle", ""}
-			}
+	recipe = {
+		{"group:seed_peanut", "group:seed_peanut", "group:seed_peanut"},
+		{"group:seed_peanut", "group:seed_peanut", "group:seed_peanut"},
+		{"", "vessels:glass_bottle", ""}
+	}
 })
 
 core.register_craft({
 	output = "cucina_vegana:corn_oil",
-	recipe = {	{"cucina_vegana:seed_corn", "cucina_vegana:seed_corn", "cucina_vegana:seed_corn"},
-				{"cucina_vegana:seed_corn", "cucina_vegana:seed_corn", "cucina_vegana:seed_corn"},
-				{"", "vessels:glass_bottle", ""}
-			}
+	recipe = {
+		{"cucina_vegana:seed_corn", "cucina_vegana:seed_corn", "cucina_vegana:seed_corn"},
+		{"cucina_vegana:seed_corn", "cucina_vegana:seed_corn", "cucina_vegana:seed_corn"},
+		{"", "vessels:glass_bottle", ""}
+	}
 })
 
 core.register_craft({
-        output = "cucina_vegana:mushroomlight_glass 4",
-        recipe = {
-                  {"","default:glass",""},
-                  {"default:glass","default:torch","default:glass"},
-                  {"","default:glass",""},
-                }
+    output = "cucina_vegana:mushroomlight_glass 4",
+	recipe = {
+        {"","default:glass",""},
+        {"default:glass","default:torch","default:glass"},
+        {"","default:glass",""},
+    }
 })
 
 
 core.register_craft({
 	output = "cucina_vegana:pizza_dough",
-	recipe = {	{"group:food_milk", "group:food_oil", "group:food_cheese"},
-				{"group:food_flour", "group:food_flour", "group:food_flour"}
-			},
+	recipe = {
+		{"group:food_milk", "group:food_oil", "group:food_cheese"},
+		{"group:food_flour", "group:food_flour", "group:food_flour"}
+	},
     replacements = {
-                    {"group:food_milk", "vessels:glass_bottle"},
-                    {"group:food_oil", "vessels:glass_bottle"},
-                    }
+        {"group:food_milk", "vessels:glass_bottle"},
+        {"group:food_oil", "vessels:glass_bottle"},
+    }
 })
 
 core.register_craft({
 	output = "cucina_vegana:pizza_vegana_raw",
-	recipe = {	{"", "cucina_vegana:sauce_hollandaise", ""},
-				{"cucina_vegana:asparagus", "cucina_vegana:lettuce", "cucina_vegana:rosemary"},
-                {"", "group:pizza_dough", ""}
-			},
+	recipe = {
+		{"", "cucina_vegana:sauce_hollandaise", ""},
+		{"cucina_vegana:asparagus", "cucina_vegana:lettuce", "cucina_vegana:rosemary"},
+        {"", "group:pizza_dough", ""}
+	},
     replacements = {
-                        {"cucina_vegana:sauce_hollandaise", "vessels:glass_bottle"},
-                    }
+        {"cucina_vegana:sauce_hollandaise", "vessels:glass_bottle"},
+    }
 
 })
 
 core.register_craft({
 	output = "cucina_vegana:pizza_funghi_raw",
-	recipe = {	{"", "group:food_oil", "cucina_vegana:rosemary"},
-				{"flowers:mushroom_brown", "cucina_vegana:imitation_meat", "flowers:mushroom_brown"},
-                {"", "group:pizza_dough", ""}
-			},
+	recipe = {
+		{"", "group:food_oil", "cucina_vegana:rosemary"},
+		{"flowers:mushroom_brown", "cucina_vegana:imitation_meat", "flowers:mushroom_brown"},
+        {"", "group:pizza_dough", ""}
+	},
     replacements = {
-                        {"group:food_oil", "vessels:glass_bottle"},
-                    }
+        {"group:food_oil", "vessels:glass_bottle"},
+    }
 
 })
 
 core.register_craft({
 	output = "cucina_vegana:plate 5",
-	recipe = {	{"group:wood", "", "group:wood"},
-				{"group:wood", "default:cobble", "group:wood"}
-			}
+	recipe = {
+		{"group:wood", "", "group:wood"},
+		{"group:wood", "default:cobble", "group:wood"}
+	}
 })
 
 core.register_craft({
 	output = "cucina_vegana:plate 2",
-	recipe = {	{"default:clay_lump", "", "default:clay_lump"},
-				{"default:clay_lump", "default:cobble", "default:clay_lump"}
-			}
+	recipe = {
+		{"default:clay_lump", "", "default:clay_lump"},
+		{"default:clay_lump", "default:cobble", "default:clay_lump"}
+	}
 })
 
 core.register_craft({
 	output = "cucina_vegana:plate 10",
-	recipe = {	{"default:steel_ingot", "", "default:steel_ingot"},
-				{"default:steel_ingot", "default:cobble", "default:steel_ingot"}
-			}
+	recipe = {
+		{"default:steel_ingot", "", "default:steel_ingot"},
+		{"default:steel_ingot", "default:cobble", "default:steel_ingot"}
+	}
 })
 
 core.register_craft({
 	output = "cucina_vegana:plate 10",
-	recipe = {	{"default:copper_ingot", "", "default:copper_ingot"},
-				{"default:copper_ingot", "default:cobble", "default:copper_ingot"}
-			}
+	recipe = {
+		{"default:copper_ingot", "", "default:copper_ingot"},
+		{"default:copper_ingot", "default:cobble", "default:copper_ingot"}
+	}
 })
 
 core.register_craft({
 	output = "cucina_vegana:plate 10",
-	recipe = {	{"default:tin_ingot", "", "default:tin_ingot"},
-				{"default:tin_ingot", "default:cobble", "default:tin_ingot"}
-			}
+	recipe = {
+		{"default:tin_ingot", "", "default:tin_ingot"},
+		{"default:tin_ingot", "default:cobble", "default:tin_ingot"}
+	}
 })
 
 core.register_craft({
 	output = "cucina_vegana:sunflower_seeds_flour",
-	recipe = {	{"default:stone", "default:stone", "default:stone"},
-				{"cucina_vegana:sunflower_seeds", "cucina_vegana:sunflower_seeds", "cucina_vegana:sunflower_seeds"},
-                {"default:cobble", "default:cobble", "default:cobble"}
-			},
+	recipe = {
+		{"default:stone", "default:stone", "default:stone"},
+		{"cucina_vegana:sunflower_seeds", "cucina_vegana:sunflower_seeds", "cucina_vegana:sunflower_seeds"},
+        {"default:cobble", "default:cobble", "default:cobble"}
+	},
     replacements = {
-                {"default:stone", "default:stone 3"},
-                {"default:cobble", "default:cobble 3"}
-            }
-
+        {"default:stone", "default:stone 3"},
+        {"default:cobble", "default:cobble 3"}
+    }
 })
 
 core.register_craft({
 	output = "cucina_vegana:sunflower_seeds_flour",
-	recipe = {	{"default:stone", "default:stone", "default:stone"},
-				{"cucina_vegana:sunflower_seeds", "cucina_vegana:sunflower_seeds", "cucina_vegana:sunflower_seeds"},
-                {"default:desert_cobble", "default:desert_cobble", "default:desert_cobble"}
-			},
+	recipe = {
+		{"default:stone", "default:stone", "default:stone"},
+		{"cucina_vegana:sunflower_seeds", "cucina_vegana:sunflower_seeds", "cucina_vegana:sunflower_seeds"},
+        {"default:desert_cobble", "default:desert_cobble", "default:desert_cobble"}
+	},
     replacements = {
-                {"default:stone", "default:stone 3"},
-                {"default:desert_cobble", "default:desert_cobble 3"}
-            }
-
+        {"default:stone", "default:stone 3"},
+        {"default:desert_cobble", "default:desert_cobble 3"}
+    }
 })
 
 core.register_craft({
 	output = "cucina_vegana:sunflower_seeds_flour",
-	recipe = {	{"default:desert_stone", "default:desert_stone", "default:desert_stone"},
-				{"cucina_vegana:sunflower_seeds", "cucina_vegana:sunflower_seeds", "cucina_vegana:sunflower_seeds"},
-                {"default:cobble", "default:cobble", "default:cobble"}
-			},
+	recipe = {
+		{"default:desert_stone", "default:desert_stone", "default:desert_stone"},
+		{"cucina_vegana:sunflower_seeds", "cucina_vegana:sunflower_seeds", "cucina_vegana:sunflower_seeds"},
+        {"default:cobble", "default:cobble", "default:cobble"}
+	},
     replacements = {
-                {"default:desert_stone", "default:desert_stone 3"},
-                {"default:cobble", "default:cobble 3"}
-            }
-
+        {"default:desert_stone", "default:desert_stone 3"},
+        {"default:cobble", "default:cobble 3"}
+    }
 })
 
 core.register_craft({
 	output = "cucina_vegana:sunflower_seeds_flour",
-	recipe = {	{"default:desert_stone", "default:desert_stone", "default:desert_stone"},
-				{"cucina_vegana:sunflower_seeds", "cucina_vegana:sunflower_seeds", "cucina_vegana:sunflower_seeds"},
-                {"default:desert_cobble", "default:desert_cobble", "default:desert_cobble"}
-			},
+	recipe = {
+		{"default:desert_stone", "default:desert_stone", "default:desert_stone"},
+		{"cucina_vegana:sunflower_seeds", "cucina_vegana:sunflower_seeds", "cucina_vegana:sunflower_seeds"},
+        {"default:desert_cobble", "default:desert_cobble", "default:desert_cobble"}
+	},
     replacements = {
-                {"default:desert_stone", "default:desert_stone 3"},
-                {"default:desert_cobble", "default:desert_cobble 3"}
-            }
-
+        {"default:desert_stone", "default:desert_stone 3"},
+        {"default:desert_cobble", "default:desert_cobble 3"}
+    }
 })
 
 core.register_craft({
 	output = "cucina_vegana:rice_flour",
-	recipe = {	{"default:stone", "default:stone", "default:stone"},
-				{"cucina_vegana:rice", "cucina_vegana:rice", "cucina_vegana:rice"},
-                {"default:cobble", "default:cobble", "default:cobble"}
-			},
+	recipe = {
+		{"default:stone", "default:stone", "default:stone"},
+		{"cucina_vegana:rice", "cucina_vegana:rice", "cucina_vegana:rice"},
+        {"default:cobble", "default:cobble", "default:cobble"}
+	},
     replacements = {
-                {"default:stone", "default:stone 3"},
-                {"default:cobble", "default:cobble 3"}
-            }
-
+        {"default:stone", "default:stone 3"},
+        {"default:cobble", "default:cobble 3"}
+    }
 })
 
 core.register_craft({
 	output = "cucina_vegana:rice_flour",
-	recipe = {	{"default:desert_stone", "default:desert_stone", "default:desert_stone"},
-				{"cucina_vegana:rice", "cucina_vegana:rice", "cucina_vegana:rice"},
-                {"default:cobble", "default:cobble", "default:cobble"}
-			},
+	recipe = {
+		{"default:desert_stone", "default:desert_stone", "default:desert_stone"},
+		{"cucina_vegana:rice", "cucina_vegana:rice", "cucina_vegana:rice"},
+        {"default:cobble", "default:cobble", "default:cobble"}
+	},
     replacements = {
-                {"default:desert_stone", "default:desert_stone 3"},
-                {"default:cobble", "default:cobble 3"}
-            }
-
+        {"default:desert_stone", "default:desert_stone 3"},
+        {"default:cobble", "default:cobble 3"}
+    }
 })
 
 core.register_craft({
 	output = "cucina_vegana:rice_flour",
-	recipe = {	{"default:desert_stone", "default:desert_stone", "default:desert_stone"},
-				{"cucina_vegana:rice", "cucina_vegana:rice", "cucina_vegana:rice"},
-                {"default:desert_cobble", "default:desert_cobble", "default:desert_cobble"}
-			},
+	recipe = {
+		{"default:desert_stone", "default:desert_stone", "default:desert_stone"},
+		{"cucina_vegana:rice", "cucina_vegana:rice", "cucina_vegana:rice"},
+        {"default:desert_cobble", "default:desert_cobble", "default:desert_cobble"}
+	},
     replacements = {
-                {"default:desert_stone", "default:desert_stone 3"},
-                {"default:desert_cobble", "default:desert_cobble 3"}
-            }
-
+        {"default:desert_stone", "default:desert_stone 3"},
+        {"default:desert_cobble", "default:desert_cobble 3"}
+    }
 })
 
 core.register_craft({
 	output = "cucina_vegana:rice_flour",
-	recipe = {	{"default:stone", "default:stone", "default:stone"},
-				{"cucina_vegana:rice", "cucina_vegana:rice", "cucina_vegana:rice"},
-                {"default:desert_cobble", "default:desert_cobble", "default:desert_cobble"}
-			},
+	recipe = {
+		{"default:stone", "default:stone", "default:stone"},
+		{"cucina_vegana:rice", "cucina_vegana:rice", "cucina_vegana:rice"},
+        {"default:desert_cobble", "default:desert_cobble", "default:desert_cobble"}
+	},
     replacements = {
-                {"default:stone", "default:stone 3"},
-                {"default:cobble", "default:cobble 3"}
-            }
-
+        {"default:stone", "default:stone 3"},
+        {"default:cobble", "default:cobble 3"}
+    }
 })
 
 core.register_craft({
 	output = "cucina_vegana:rice_starch 2",
-	recipe = {	{"wool:white", "cucina_vegana:rice", "wool:white"},
-				{"wool:white", "cucina_vegana:rice", "wool:white"},
-                {"", "bucket:bucket_water", ""}
-			},
+	recipe = {
+		{"wool:white", "cucina_vegana:rice", "wool:white"},
+		{"wool:white", "cucina_vegana:rice", "wool:white"},
+        {"", "bucket:bucket_water", ""}
+	},
     replacements = {
-                {"wool:white", "farming:cotton 2"},
-                {"bucket:bucket_water", "bucket:bucket_empty"}
-            }
-
+        {"wool:white", "farming:cotton 2"},
+        {"bucket:bucket_water", "bucket:bucket_empty"}
+    }
 })
 
 core.register_craft({
 	output = "cucina_vegana:rice_starch 2",
-	recipe = {	{"wool:white", "cucina_vegana:rice", "wool:white"},
-				{"wool:white", "cucina_vegana:rice", "wool:white"},
-                {"", "bucket:bucket_river_water", ""}
-			},
+	recipe = {
+		{"wool:white", "cucina_vegana:rice", "wool:white"},
+		{"wool:white", "cucina_vegana:rice", "wool:white"},
+        {"", "bucket:bucket_river_water", ""}
+	},
     replacements = {
-                {"wool:white", "farming:cotton 2"},
-                {"bucket:bucket_river_water", "bucket:bucket_empty"}
-            }
-
+        {"wool:white", "farming:cotton 2"},
+        {"bucket:bucket_river_water", "bucket:bucket_empty"}
+    }
 })
 
 core.register_craft({
 	output = "wool:white",
-	recipe = {	{"cucina_vegana:flax_roasted", "cucina_vegana:flax_roasted", "cucina_vegana:flax_roasted"},
-				{"cucina_vegana:flax_roasted", "cucina_vegana:flax_roasted", "cucina_vegana:flax_roasted"},
-			}
+	recipe = {
+		{"cucina_vegana:flax_roasted", "cucina_vegana:flax_roasted", "cucina_vegana:flax_roasted"},
+		{"cucina_vegana:flax_roasted", "cucina_vegana:flax_roasted", "cucina_vegana:flax_roasted"},
+	}
 })
 
 --   *******************************************
@@ -382,61 +407,64 @@ core.register_craft({
 
 core.register_craft({
 	output = "cucina_vegana:imitation_butter",
-	recipe = {	{"group:dye,color_yellow", "cucina_vegana:soy_milk",  "cucina_vegana:soy_milk"}
-			},
-			replacements = {
-                            {"cucina_vegana:soy_milk", "vessels:drinking_glass 2"}
-						}
+	recipe = {
+		{"group:dye,color_yellow", "cucina_vegana:soy_milk", "cucina_vegana:soy_milk"}
+	},
+	replacements = {
+        {"cucina_vegana:soy_milk", "vessels:drinking_glass 2"}
+	}
 })
 
 core.register_craft({
 	output = "cucina_vegana:imitation_cheese",
-	recipe = {	{"group:dye,color_orange","cucina_vegana:imitation_butter", "cucina_vegana:imitation_butter"}
-			},
+	recipe = {
+		{"group:dye,color_orange","cucina_vegana:imitation_butter", "cucina_vegana:imitation_butter"}
+	}
 })
 
 core.register_craft({
 	output = "cucina_vegana:imitation_fish",
 	recipe = {
-				{"group:dye,color_blue","cucina_vegana:tofu", "group:dye,color_blue"},
-				{"cucina_vegana:tofu","cucina_vegana:tofu", "cucina_vegana:tofu"},
-				{"","cucina_vegana:tofu", ""},
-
-			},
+		{"group:dye,color_blue","cucina_vegana:tofu", "group:dye,color_blue"},
+		{"cucina_vegana:tofu","cucina_vegana:tofu", "cucina_vegana:tofu"},
+		{"","cucina_vegana:tofu", ""},
+	}
 })
 
 core.register_craft({
 	output = "cucina_vegana:imitation_meat",
-	recipe = {	{"group:dye,color_red", "cucina_vegana:tofu", "group:dye,color_white"},
-				{"", "cucina_vegana:tofu", ""},
-				{"", "cucina_vegana:tofu", ""}
-			},
+	recipe = {
+		{"group:dye,color_red", "cucina_vegana:tofu", "group:dye,color_white"},
+		{"", "cucina_vegana:tofu", ""},
+		{"", "cucina_vegana:tofu", ""}
+	}
 })
 
 core.register_craft({
 	output = "cucina_vegana:imitation_poultry",
-	recipe = {	{"cucina_vegana:tofu", "", "group:dye,color_yellow"},
-				{"", "cucina_vegana:tofu", ""},
-				{"cucina_vegana:tofu", "cucina_vegana:tofu", "cucina_vegana:tofu"}
-			},
+	recipe = {
+		{"cucina_vegana:tofu", "", "group:dye,color_yellow"},
+		{"", "cucina_vegana:tofu", ""},
+		{"cucina_vegana:tofu", "cucina_vegana:tofu", "cucina_vegana:tofu"}
+	}
 })
 
 core.register_craft({
 	output = "cucina_vegana:soy_milk",
 	recipe = {
-			{"cucina_vegana:soy", "cucina_vegana:soy", "cucina_vegana:soy"},
-			{"", "cucina_vegana:soy", ""},
-			{"", "vessels:drinking_glass", ""},
-		},
+		{"cucina_vegana:soy", "cucina_vegana:soy", "cucina_vegana:soy"},
+		{"", "cucina_vegana:soy", ""},
+		{"", "vessels:drinking_glass", ""},
+	}
 })
 
 core.register_craft({
 	output = "cucina_vegana:tofu",
 	recipe = {
-			{"cucina_vegana:soy", "cucina_vegana:soy", "cucina_vegana:soy"},
-			{"cucina_vegana:soy", "cucina_vegana:soy", "cucina_vegana:soy"},
-			{"cucina_vegana:soy", "cucina_vegana:soy", "cucina_vegana:soy"},
-		},
+		{"cucina_vegana:soy", "cucina_vegana:soy", "cucina_vegana:soy"},
+		{"cucina_vegana:soy", "cucina_vegana:soy", "cucina_vegana:soy"},
+		{"cucina_vegana:soy", "cucina_vegana:soy", "cucina_vegana:soy"},
+	}
 })
 
 --   *******************************************
@@ -445,147 +473,153 @@ core.register_craft({
 
 core.register_craft({
 	output = "cucina_vegana:blueberry_jam",
-	recipe = {	{"cucina_vegana:blueberry_pot_cooked", "", ""},
-                {"group:wool", "", ""},
-				{"vessels:glass_bottle", "", ""}
-			},
+	recipe = {
+		{"cucina_vegana:blueberry_pot_cooked", "", ""},
+        {"group:wool", "", ""},
+		{"vessels:glass_bottle", "", ""}
+	},
     replacements = {
-            {"cucina_vegana:blueberry_pot_cooked", "bucket:bucket_empty"},
-            {"group:wool", "farming:cotton"}
-                   }
+    	{"cucina_vegana:blueberry_pot_cooked", "bucket:bucket_empty"},
+        {"group:wool", "farming:cotton"}
+    }
 })
 
 core.register_craft({
 	output = "cucina_vegana:cucumber_in_glass",
-	recipe = {	{"cucina_vegana:cucumber", "cucina_vegana:cucumber", "cucina_vegana:cucumber"},
-                {"", "cucina_vegana:cucumber", ""},
-				{"", "vessels:glass_bottle", ""}
-			},
+	recipe = {
+		{"cucina_vegana:cucumber", "cucina_vegana:cucumber", "cucina_vegana:cucumber"},
+        {"", "cucina_vegana:cucumber", ""},
+		{"", "vessels:glass_bottle", ""}
+	}
 })
 
 core.register_craft({
 	output = "cucina_vegana:bowl_rice",
 	recipe = {
-				{"cucina_vegana:rice"},
-				{"bucket:bucket_water"},
-				{"group:food_bowl"},
-			},
-			replacements = {
-							{"bucket:bucket_water", "bucket:bucket_empty"},
-						}
+		{"cucina_vegana:rice"},
+		{"bucket:bucket_water"},
+		{"group:food_bowl"},
+	},
+	replacements = {
+		{"bucket:bucket_water", "bucket:bucket_empty"},
+	}
 })
 
 core.register_craft({
 	output = "cucina_vegana:bowl_rice",
 	recipe = {
-				{"cucina_vegana:rice"},
-				{"bucket:bucket_river_water"},
-				{"group:food_bowl"},
-			},
-			replacements = {
-							{"bucket:bucket_river_water", "bucket:bucket_empty"},
-						}
+		{"cucina_vegana:rice"},
+		{"bucket:bucket_river_water"},
+		{"group:food_bowl"},
+	},
+	replacements = {
+		{"bucket:bucket_river_water", "bucket:bucket_empty"},
+	}
 })
 
 core.register_craft({
 	output = "cucina_vegana:dandelion_honey",
-	recipe = {	{"cucina_vegana:dandelion_suds_cooking", "", ""},
-                {"group:wool", "", ""},
-				{"vessels:glass_bottle", "", ""}
-			},
+	recipe = {
+		{"cucina_vegana:dandelion_suds_cooking", "", ""},
+        {"group:wool", "", ""},
+		{"vessels:glass_bottle", "", ""}
+	},
     replacements = {
-            {"cucina_vegana:dandelion_suds_cooking", "bucket:bucket_empty"},
-            {"group:wool", "farming:cotton 2"}
-                   }
+        {"cucina_vegana:dandelion_suds_cooking", "bucket:bucket_empty"},
+        {"group:wool", "farming:cotton 2"}
+    }
 })
 
 core.register_craft({
 	output = "cucina_vegana:edamame",
-	recipe = {	{"cucina_vegana:rosemary", "group:seed_soy", "cucina_vegana:peanut"},
-                {"group:seed_soy", "group:seed_soy", "group:seed_soy"},
-				{"", "group:food_plate", ""}
-			}
+	recipe = {
+		{"cucina_vegana:rosemary", "group:seed_soy", "cucina_vegana:peanut"},
+        {"group:seed_soy", "group:seed_soy", "group:seed_soy"},
+		{"", "group:food_plate", ""}
+	}
 })
 
 core.register_craft({
 	output = "cucina_vegana:sauce_hollandaise",
-	recipe = {	{"cucina_vegana:parsley", "group:food_butter", "cucina_vegana:rosemary"},
-				{"", "cucina_vegana:soy_milk", ""},
-				{"", "vessels:glass_bottle", ""}
-			},
+	recipe = {
+		{"cucina_vegana:parsley", "group:food_butter", "cucina_vegana:rosemary"},
+		{"", "cucina_vegana:soy_milk", ""},
+		{"", "vessels:glass_bottle", ""}
+	},
     replacements = {
-            {"cucina_vegana:soy_milk", "vessels:glass_bottle"}
-                   }
+    	{"cucina_vegana:soy_milk", "vessels:glass_bottle"}
+    }
 })
 
 core.register_craft({
 	output = "cucina_vegana:sunflower_seeds_oil",
-	recipe = {	{"cucina_vegana:sunflower_seeds", "cucina_vegana:sunflower_seeds", "cucina_vegana:sunflower_seeds"},
-				{"cucina_vegana:sunflower_seeds", "cucina_vegana:sunflower_seeds", "cucina_vegana:sunflower_seeds"},
-				{"", "vessels:glass_bottle", ""}
-			}
+	recipe = {
+		{"cucina_vegana:sunflower_seeds", "cucina_vegana:sunflower_seeds", "cucina_vegana:sunflower_seeds"},
+		{"cucina_vegana:sunflower_seeds", "cucina_vegana:sunflower_seeds", "cucina_vegana:sunflower_seeds"},
+		{"", "vessels:glass_bottle", ""}
+	}
 })
 
 core.register_craft({
 	output = "cucina_vegana:molasses",
 	recipe = {
-				{"", "default:stick", ""},
-				{"cucina_vegana:kohlrabi", "vessels:drinking_glass", "cucina_vegana:kohlrabi"},
-                {"", "bucket:bucket_water", ""},
-			},
-			replacements = {
-							{"bucket:bucket_water", "bucket:bucket_empty"},
-                            {"default:stick", "default:stick"}
-						}
+		{"", "default:stick", ""},
+		{"cucina_vegana:kohlrabi", "vessels:drinking_glass", "cucina_vegana:kohlrabi"},
+        {"", "bucket:bucket_water", ""},
+	},
+	replacements = {
+		{"bucket:bucket_water", "bucket:bucket_empty"},
+        {"default:stick", "default:stick"}
+	}
 })
 
 core.register_craft({
 	output = "cucina_vegana:molasses",
 	recipe = {
-				{"", "default:stick", ""},
-				{"cucina_vegana:kohlrabi", "vessels:drinking_glass", "cucina_vegana:kohlrabi"},
-                {"", "bucket:bucket_river_water", ""},
-			},
-			replacements = {
-							{"bucket:bucket_river_water", "bucket:bucket_empty"},
-                            {"default:stick", "default:stick"}
-						}
+		{"", "default:stick", ""},
+		{"cucina_vegana:kohlrabi", "vessels:drinking_glass", "cucina_vegana:kohlrabi"},
+        {"", "bucket:bucket_river_water", ""},
+	},
+	replacements = {
+		{"bucket:bucket_river_water", "bucket:bucket_empty"},
+        {"default:stick", "default:stick"}
+	}
 })
 
 core.register_craft({
 	output = "cucina_vegana:peanut_butter",
 	recipe = {
-				{"cucina_vegana:peanut", "default:stick", "cucina_vegana:peanut"},
-				{"cucina_vegana:peanut", "group:food_butter", "cucina_vegana:peanut"},
-                {"", "vessels:glass_bottle", ""},
-			},
-			replacements = {
-							{"default:stick", "default:stick"},
-						}
+		{"cucina_vegana:peanut", "default:stick", "cucina_vegana:peanut"},
+		{"cucina_vegana:peanut", "group:food_butter", "cucina_vegana:peanut"},
+        {"", "vessels:glass_bottle", ""},
+	},
+	replacements = {
+		{"default:stick", "default:stick"},
+	}
 })
 
 core.register_craft({
 	output = "cucina_vegana:vegan_strawberry_milk",
 	recipe = {
-				{"cucina_vegana:strawberry", "default:stick", "cucina_vegana:strawberry"},
-				{"cucina_vegana:strawberry", "cucina_vegana:strawberry", "cucina_vegana:strawberry"},
-                {"", "cucina_vegana:soy_milk", ""},
-			},
-			replacements = {
-							{"default:stick", "default:stick"},
-						}
+		{"cucina_vegana:strawberry", "default:stick", "cucina_vegana:strawberry"},
+		{"cucina_vegana:strawberry", "cucina_vegana:strawberry", "cucina_vegana:strawberry"},
+        {"", "cucina_vegana:soy_milk", ""},
+	},
+	replacements = {
+		{"default:stick", "default:stick"},
+	}
 })
 
 core.register_craft({
 	output = "cucina_vegana:vegan_strawberry_milk",
 	recipe = {
-				{"group:food_strawberry", "default:stick", "group:food_strawberry"},
-				{"group:food_strawberry", "group:food_strawberry", "group:food_strawberry"},
-                {"", "cucina_vegana:soy_milk", ""},
-			},
-			replacements = {
-							{"default:stick", "default:stick"},
-						}
+		{"group:food_strawberry", "default:stick", "group:food_strawberry"},
+		{"group:food_strawberry", "group:food_strawberry", "group:food_strawberry"},
+        {"", "cucina_vegana:soy_milk", ""},
+	},
+	replacements = {
+		{"default:stick", "default:stick"},
+	}
 })
 --   *******************************************
 --   *****           Dinners               *****
@@ -593,160 +627,173 @@ core.register_craft({
 
 core.register_craft({
 	output = "cucina_vegana:asparagus_hollandaise",
-	recipe = {	{"cucina_vegana:asparagus", "cucina_vegana:sauce_hollandaise", "cucina_vegana:parsley"},
-				{"", "group:food_plate", ""}
-			},
-			replacements = {	{"group:food_sauce", "vessels:glass_bottle"},
-						}
+	recipe = {
+		{"cucina_vegana:asparagus", "cucina_vegana:sauce_hollandaise", "cucina_vegana:parsley"},
+		{"", "group:food_plate", ""}
+	},
+	replacements = {
+		{"group:food_sauce", "vessels:glass_bottle"},
+	}
 })
 
 core.register_craft({
 	output = "cucina_vegana:asparagus_rice",
 	recipe = {
-				{"cucina_vegana:asparagus", "group:food_rice", "group:food_butter"},
-				{"", "group:food_plate", ""}
-			},
-			replacements = {
-							{"group:food_rice", "cucina_vegana:bowl"},
-						}
+		{"cucina_vegana:asparagus", "group:food_rice", "group:food_butter"},
+		{"", "group:food_plate", ""}
+	},
+	replacements = {
+		{"group:food_rice", "cucina_vegana:bowl"},
+	}
 })
 
 core.register_craft({
 	output = "cucina_vegana:asparagus_soup",
-	recipe = {	{"cucina_vegana:chives", "group:food_oil", "cucina_vegana:asparagus"},
-				{"", "cucina_vegana:soy_milk", ""},
-				{"", "group:food_plate", ""}
-			},
-			replacements = {{"group:food_milk", "vessels:glass_bottle"},
-						   {"group:food_oil", "vessels:glass_bottle"},
-						}
+	recipe = {
+		{"cucina_vegana:chives", "group:food_oil", "cucina_vegana:asparagus"},
+		{"", "cucina_vegana:soy_milk", ""},
+		{"", "group:food_plate", ""}
+	},
+	replacements = {
+		{"group:food_milk", "vessels:glass_bottle"},
+		{"group:food_oil", "vessels:glass_bottle"},
+	}
 })
 
 core.register_craft({
 	output = "cucina_vegana:fish_parsley_rosemary",
 	recipe = {
-				{"cucina_vegana:parsley","group:food_oil", "cucina_vegana:rosemary"},
-				{"","group:food_fish", ""},
-				{"","group:food_plate", ""},
-			},
-			replacements = {
-							{"group:food_oil", "vessels:glass_bottle"},
-						}
+		{"cucina_vegana:parsley","group:food_oil", "cucina_vegana:rosemary"},
+		{"","group:food_fish", ""},
+		{"","group:food_plate", ""},
+	},
+	replacements = {
+		{"group:food_oil", "vessels:glass_bottle"},
+	}
 })
 
 core.register_craft({
 	output = "cucina_vegana:fryer_raw",
 	recipe = {
-				{"default:paper","", "default:paper"},
-				{"cucina_vegana:parsley","cucina_vegana:molasses", "cucina_vegana:rosemary"},
-				{"","cucina_vegana:imitation_poultry", ""},
-			},
-			replacements = {
-							{"cucina_vegana:molasses", "vessels:drinking_glass"},
-						}
+		{"default:paper","", "default:paper"},
+		{"cucina_vegana:parsley","cucina_vegana:molasses", "cucina_vegana:rosemary"},
+		{"","cucina_vegana:imitation_poultry", ""},
+	},
+	replacements = {
+		{"cucina_vegana:molasses", "vessels:drinking_glass"},
+	}
 })
 
 core.register_craft({
 	output = "cucina_vegana:fryer_raw",
 	recipe = {
-				{"default:paper","", "default:paper"},
-				{"cucina_vegana:potato","cucina_vegana:parsley", "cucina_vegana:potato"},
-				{"cucina_vegana:carrot","cucina_vegana:imitation_poultry", "cucina_vegana:carrot"},
-			},
+		{"default:paper","", "default:paper"},
+		{"cucina_vegana:potato","cucina_vegana:parsley", "cucina_vegana:potato"},
+		{"cucina_vegana:carrot","cucina_vegana:imitation_poultry", "cucina_vegana:carrot"},
+	}
 })
 
 core.register_craft({
 	output = "cucina_vegana:kohlrabi_soup",
-	recipe = {	{"cucina_vegana:kohlrabi", "group:food_oil", "cucina_vegana:parsley"},
-				{"", "bucket:bucket_water", ""},
-				{"", "group:food_plate", ""}
-			},
-			replacements = {{"bucket:bucket_water", "bucket:bucket_empty"},
-						   {"group:food_oil", "vessels:glass_bottle"},
-						}
+	recipe = {
+		{"cucina_vegana:kohlrabi", "group:food_oil", "cucina_vegana:parsley"},
+		{"", "bucket:bucket_water", ""},
+		{"", "group:food_plate", ""}
+	},
+	replacements = {
+		{"bucket:bucket_water", "bucket:bucket_empty"},
+		{"group:food_oil", "vessels:glass_bottle"},
+	}
 })
 
 core.register_craft({
 	output = "cucina_vegana:kohlrabi_soup",
-	recipe = {	{"cucina_vegana:kohlrabi", "group:food_oil", "cucina_vegana:parsley"},
-				{"", "bucket:bucket_river_water", ""},
-				{"", "group:food_plate", ""}
-			},
-			replacements = {{"bucket:bucket_river_water", "bucket:bucket_empty"},
-						   {"group:food_oil", "vessels:glass_bottle"},
-						}
+	recipe = {
+		{"cucina_vegana:kohlrabi", "group:food_oil", "cucina_vegana:parsley"},
+		{"", "bucket:bucket_river_water", ""},
+		{"", "group:food_plate", ""}
+	},
+	replacements = {
+		{"bucket:bucket_river_water", "bucket:bucket_empty"},
+		{"group:food_oil", "vessels:glass_bottle"},
+	}
 })
 
 core.register_craft({
 	output = "cucina_vegana:salad_bowl",
-	recipe = {	{"cucina_vegana:parsley", "cucina_vegana:lettuce", "cucina_vegana:chives"},
-				{"", "group:food_oil", ""},
-				{"", "group:food_bowl", ""}
-			},
-            replacements = {
-                            {"group:food_oil", "vessels:glass_bottle"}
-                           }
+	recipe = {
+		{"cucina_vegana:parsley", "cucina_vegana:lettuce", "cucina_vegana:chives"},
+		{"", "group:food_oil", ""},
+		{"", "group:food_bowl", ""}
+	},
+    replacements = {
+        {"group:food_oil", "vessels:glass_bottle"}
+	}
 })
 
 core.register_craft({
 	output = "cucina_vegana:salad_hollandaise",
 	recipe = {
-				{"cucina_vegana:sauce_hollandaise", "cucina_vegana:salad_bowl", ""}
-			},
-            replacements = {
-                            {"cucina_vegana:sauce_hollandaise", "vessels:glass_bottle"},
-                           }
+		{"cucina_vegana:sauce_hollandaise", "cucina_vegana:salad_bowl", ""}
+	},
+    replacements = {
+        {"cucina_vegana:sauce_hollandaise", "vessels:glass_bottle"},
+    }
 })
 
 core.register_craft({
 	output = "cucina_vegana:salad_hollandaise",
-	recipe = {	{"cucina_vegana:parsley", "cucina_vegana:lettuce", "cucina_vegana:chives"},
-				{"cucina_vegana:sauce_hollandaise", "group:food_oil", ""},
-				{"", "group:food_bowl", ""}
-			},
+	recipe = {
+		{"cucina_vegana:parsley", "cucina_vegana:lettuce", "cucina_vegana:chives"},
+		{"cucina_vegana:sauce_hollandaise", "group:food_oil", ""},
+		{"", "group:food_bowl", ""}
+	},
     replacements = {
-                {"group:food_oil", "vessels:glass_bottle"},
-				{"cucina_vegana:sauce_hollandaise", "vessels:glass_bottle"}
-			}
-
+        {"group:food_oil", "vessels:glass_bottle"},
+		{"cucina_vegana:sauce_hollandaise", "vessels:glass_bottle"}
+	}
 })
 
 core.register_craft({
 	output = "cucina_vegana:sea_salad",
-	recipe = {	{"default:jungleleaves", "cucina_vegana:parsley", "cucina_vegana:lettuce"},
-				{"cucina_vegana:chives", "bucket:bucket_water", "cucina_vegana:asparagus"},
-				{"", "group:food_bowl", ""}
-			},
+	recipe = {
+		{"default:jungleleaves", "cucina_vegana:parsley", "cucina_vegana:lettuce"},
+		{"cucina_vegana:chives", "bucket:bucket_water", "cucina_vegana:asparagus"},
+		{"", "group:food_bowl", ""}
+	},
     replacements = {
-                {"bucket:bucket_water", "bucket:bucket_empty"},
-			}
-
+        {"bucket:bucket_water", "bucket:bucket_empty"},
+	}
 })
 
 core.register_craft({
 	output = "cucina_vegana:soy_soup",
-	recipe = {	{"cucina_vegana:chives", "group:food_oil", "cucina_vegana:parsley"},
-				{"", "cucina_vegana:soy_milk", ""},
-				{"", "group:food_plate", ""}
-			},
-			replacements = {{"group:food_milk", "vessels:glass_bottle"},
-						   {"group:food_oil", "vessels:glass_bottle"},
-						}
+	recipe = {
+		{"cucina_vegana:chives", "group:food_oil", "cucina_vegana:parsley"},
+		{"", "cucina_vegana:soy_milk", ""},
+		{"", "group:food_plate", ""}
+	},
+	replacements = {
+		{"group:food_milk", "vessels:glass_bottle"},
+		{"group:food_oil", "vessels:glass_bottle"},
+	}
 })
 
 core.register_craft({
 	output = "cucina_vegana:tofu_chives_rosemary",
-	recipe = {	{"cucina_vegana:chives", "", "cucina_vegana:rosemary"},
-				{"", "cucina_vegana:tofu", ""},
-				{"", "group:food_plate", ""}
-			},
+	recipe = {
+		{"cucina_vegana:chives", "", "cucina_vegana:rosemary"},
+		{"", "cucina_vegana:tofu", ""},
+		{"", "group:food_plate", ""}
+	},
 })
 
 core.register_craft({
 	output = "cucina_vegana:vegan_sushi",
-	recipe = {	{"cucina_vegana:imitation_fish", "cucina_vegana:bowl_rice", ""},
-				{"default:papyrus", "", ""}
-			},
+	recipe = {
+		{"cucina_vegana:imitation_fish", "cucina_vegana:bowl_rice", ""},
+		{"default:papyrus", "", ""}
+	},
 	replacements = {
 		{"cucina_vegana:bowl_rice", "cucina_vegana:bowl"}
 	}
@@ -767,123 +814,133 @@ core.register_craft({
 
 core.register_craft({
 	output = "cucina_vegana:sunflower_seeds_dough",
-	recipe = {	{"", "cucina_vegana:sunflower_seeds", ""},
-				{"farming:flour", "farming:flour", "farming:flour"}
-			}
+	recipe = {
+		{"", "cucina_vegana:sunflower_seeds", ""},
+		{"farming:flour", "farming:flour", "farming:flour"}
+	}
 })
 
 core.register_craft({
 	output = "cucina_vegana:sunflower_seeds_dough",
-	recipe = {	{"", "cucina_vegana:sunflower_seeds", ""},
-				{"group:food_flour", "group:food_flour", "group:food_flour"}
-			}
+	recipe = {
+		{"", "cucina_vegana:sunflower_seeds", ""},
+		{"group:food_flour", "group:food_flour", "group:food_flour"}
+	}
 })
 
 
 core.register_craft({
 	output = "default:paper 4",
-	recipe = {	{"default:stone", "cucina_vegana:flax_roasted", "default:stone"},
-				{"default:stone", "cucina_vegana:flax_roasted", "default:stone"},
-                {"", "bucket:bucket_water", ""},
-			},
+	recipe = {
+		{"default:stone", "cucina_vegana:flax_roasted", "default:stone"},
+		{"default:stone", "cucina_vegana:flax_roasted", "default:stone"},
+        {"", "bucket:bucket_water", ""},
+	},
     replacements = {
-                    {"default:stone", "default:stone 4"},
-                    {"bucket:bucket_water", "bucket:bucket_empty"},
-                    }
+        {"default:stone", "default:stone 4"},
+        {"bucket:bucket_water", "bucket:bucket_empty"},
+    }
 })
 
 core.register_craft({
 	output = "default:paper 4",
-	recipe = {	{"default:desert_stone", "cucina_vegana:flax_roasted", "default:desert_stone"},
-				{"default:desert_stone", "cucina_vegana:flax_roasted", "default:desert_stone"},
-                {"", "bucket:bucket_water", ""},
-			},
+	recipe = {
+		{"default:desert_stone", "cucina_vegana:flax_roasted", "default:desert_stone"},
+		{"default:desert_stone", "cucina_vegana:flax_roasted", "default:desert_stone"},
+        {"", "bucket:bucket_water", ""},
+	},
     replacements = {
-                    {"default:desert_stone", "default:desert_stone 4"},
-                    {"bucket:bucket_water", "bucket:bucket_empty"},
-                    }
+    	{"default:desert_stone", "default:desert_stone 4"},
+        {"bucket:bucket_water", "bucket:bucket_empty"},
+    }
 })
 
 core.register_craft({
 	output = "default:paper 4",
-	recipe = {	{"default:cobble", "cucina_vegana:flax_roasted", "default:cobble"},
-				{"default:cobble", "cucina_vegana:flax_roasted", "default:cobble"},
-                {"", "bucket:bucket_water", ""},
-			},
+	recipe = {
+		{"default:cobble", "cucina_vegana:flax_roasted", "default:cobble"},
+		{"default:cobble", "cucina_vegana:flax_roasted", "default:cobble"},
+        {"", "bucket:bucket_water", ""},
+	},
     replacements = {
-                    {"default:cobble", "default:cobble 4"},
-                    {"bucket:bucket_water", "bucket:bucket_empty"},
-                    }
+        {"default:cobble", "default:cobble 4"},
+        {"bucket:bucket_water", "bucket:bucket_empty"},
+    }
 })
 
 core.register_craft({
 	output = "default:paper 4",
-	recipe = {	{"default:desert_cobble", "cucina_vegana:flax_roasted", "default:desert_cobble"},
-				{"default:desert_cobble", "cucina_vegana:flax_roasted", "default:desert_cobble"},
-                {"", "bucket:bucket_water", ""},
-			},
+	recipe = {
+		{"default:desert_cobble", "cucina_vegana:flax_roasted", "default:desert_cobble"},
+		{"default:desert_cobble", "cucina_vegana:flax_roasted", "default:desert_cobble"},
+        {"", "bucket:bucket_water", ""},
+	},
     replacements = {
-                    {"default:desert_cobble", "default:desert_cobble 4"},
-                    {"bucket:bucket_water", "bucket:bucket_empty"},
-                    }
+        {"default:desert_cobble", "default:desert_cobble 4"},
+        {"bucket:bucket_water", "bucket:bucket_empty"},
+    }
 })
 
 core.register_craft({
 	output = "default:paper 4",
-	recipe = {	{"default:stone", "cucina_vegana:flax_roasted", "default:stone"},
-				{"default:stone", "cucina_vegana:flax_roasted", "default:stone"},
-                {"", "bucket:bucket_river_water", ""},
-			},
+	recipe = {
+		{"default:stone", "cucina_vegana:flax_roasted", "default:stone"},
+		{"default:stone", "cucina_vegana:flax_roasted", "default:stone"},
+        {"", "bucket:bucket_river_water", ""},
+	},
     replacements = {
-                    {"default:stone", "default:stone 4"},
-                    {"bucket:bucket_river_water", "bucket:bucket_empty"},
-                    }
+        {"default:stone", "default:stone 4"},
+        {"bucket:bucket_river_water", "bucket:bucket_empty"},
+    }
 })
 
 core.register_craft({
 	output = "default:paper 4",
-	recipe = {	{"default:desert_stone", "cucina_vegana:flax_roasted", "default:desert_stone"},
-				{"default:desert_stone", "cucina_vegana:flax_roasted", "default:desert_stone"},
-                {"", "bucket:bucket_river_water", ""},
-			},
+	recipe = {
+		{"default:desert_stone", "cucina_vegana:flax_roasted", "default:desert_stone"},
+		{"default:desert_stone", "cucina_vegana:flax_roasted", "default:desert_stone"},
+        {"", "bucket:bucket_river_water", ""},
+	},
     replacements = {
-                    {"default:desert_stone", "default:desert_stone 4"},
-                    {"bucket:bucket_river_water", "bucket:bucket_empty"},
-                    }
+        {"default:desert_stone", "default:desert_stone 4"},
+    	{"bucket:bucket_river_water", "bucket:bucket_empty"},
+    }
 })
 
 core.register_craft({
 	output = "default:paper 4",
-	recipe = {	{"default:cobble", "cucina_vegana:flax_roasted", "default:cobble"},
-				{"default:cobble", "cucina_vegana:flax_roasted", "default:cobble"},
-                {"", "bucket:bucket_river_water", ""},
-			},
+	recipe = {
+		{"default:cobble", "cucina_vegana:flax_roasted", "default:cobble"},
+		{"default:cobble", "cucina_vegana:flax_roasted", "default:cobble"},
+        {"", "bucket:bucket_river_water", ""},
+	},
     replacements = {
-                    {"default:cobble", "default:cobble 4"},
-                    {"bucket:bucket_river_water", "bucket:bucket_empty"},
-                    }
+        {"default:cobble", "default:cobble 4"},
+        {"bucket:bucket_river_water", "bucket:bucket_empty"},
+    }
 })
 
 core.register_craft({
 	output = "default:paper 4",
-	recipe = {	{"default:desert_cobble", "cucina_vegana:flax_roasted", "default:desert_cobble"},
-				{"default:desert_cobble", "cucina_vegana:flax_roasted", "default:desert_cobble"},
-                {"", "bucket:bucket_river_water", ""},
-			},
+	recipe = {
+		{"default:desert_cobble", "cucina_vegana:flax_roasted", "default:desert_cobble"},
+		{"default:desert_cobble", "cucina_vegana:flax_roasted", "default:desert_cobble"},
+        {"", "bucket:bucket_river_water", ""},
+	},
     replacements = {
-                    {"default:desert_cobble", "default:desert_cobble 4"},
-                    {"bucket:bucket_river_water", "bucket:bucket_empty"},
-                    }
+        {"default:desert_cobble", "default:desert_cobble 4"},
+        {"bucket:bucket_river_water", "bucket:bucket_empty"},
+    }
 })
 
 core.register_craft({
 	output = "farming:cotton 2",
 	recipe = {
-              {"cucina_vegana:flax_roasted","default:stick","cucina_vegana:flax_roasted"},
-            },
+        {"cucina_vegana:flax_roasted","default:stick","cucina_vegana:flax_roasted"},
+    },
     replacements = {
-                    {"default:stick", "default:stick"},
-                },
+        {"default:stick", "default:stick"},
+    },
 })
 
 core.register_craft({

--- a/recipes_5xx.lua
+++ b/recipes_5xx.lua
@@ -33,7 +33,7 @@ local nodes = {
 }
 
 for node, value in ipairs(nodes) do
-    if(core.registered_nodes[value.name] or core.registered_items[value.name]) then
+    if core.registered_nodes[value.name] or core.registered_items[value.name] then
         core.register_craft({
             output = value.output,
             recipe = value.recipe,

--- a/recipes_support.lua
+++ b/recipes_support.lua
@@ -8,14 +8,8 @@ local modname = core.get_current_modname()
 --   ** Additional Recipes with other Mods  **
 --   *******************************************
 
---[[
-        **************************************************
-        ***             Support for mobs               ***
-        **************************************************
-]]--
-
+-- Support for mobs
 if core.get_modpath("mobs") then
-
 	core.register_craft({
 		output = "mobs:meat_raw",
 		recipe = {
@@ -33,17 +27,10 @@ if core.get_modpath("mobs") then
 	})
 
     core.log("info", "[MOD] " .. modname .. ": mobs supported.")
+end
 
-end -- if core.get_modpath("mobs"
-
---[[
-        **************************************************
-        ***      Support for animalmaterials           ***
-        **************************************************
-]]--
-
+-- Support for animalmaterials
 if core.get_modpath("animalmaterials") then
-
 	core.register_craft({
 		output = "animalmaterials:milk",
 		recipe = {
@@ -55,16 +42,10 @@ if core.get_modpath("animalmaterials") then
 
     core.log("info", "[MOD] " .. modname .. ": animalmaterials supported.")
 
-end -- if core.get_modpath("animalmaterials"
+end
 
---[[
-        **************************************************
-        ***             Support for fishing            ***
-        **************************************************
-]]--
-
+-- Support for fishing
 if core.get_modpath("fishing") then
-
     cucina_vegana.add_group("fishing:fish_raw", {food_fish = 1})
     cucina_vegana.add_group("fishing:clownfish_raw", {food_fish = 1})
     cucina_vegana.add_group("fishing:bluewhite_raw", {food_fish = 1})
@@ -105,56 +86,49 @@ if core.get_modpath("fishing") then
 	})
 
     core.log("info", "[MOD] " .. modname .. ": fishing supported.")
+end
 
-end -- if core.get_modpath("fishing"
-
---[[
-        **************************************************
-        ***               Support for bbq              ***
-        **************************************************
-]]--
-
+-- Support for bbq
 if core.get_modpath("bbq") then
-
 	-- *** group:food_meat
 
 	--BBQ Beef Ribs Craft Recipe
-	core.register_craft( {
+	core.register_craft({
 		output = "bbq:bbq_beef_ribs_raw 2",
 		type = "shapeless",
 		recipe = {"bbq:bbq_sauce", "group:food_meat", "group:food_pepper_ground"}
 	})
 
 	--Corned Beef Craft Recipe
-	core.register_craft( {
+	core.register_craft({
 		output = "bbq:corned_beef_raw",
 		type = "shapeless",
 		recipe = {"group:food_peppercorn", "group:food_meat","bbq:brine",}
 	})
 
 	--BBQ Brisket Craft Recipe
-	core.register_craft( {
+	core.register_craft({
 		output = "bbq:brisket_raw 2",
 		type = "shapeless",
 		recipe = {"bbq:bbq_sauce", "bbq:molasses", "group:food_meat", "group:food_garlic_clove"}
 	})
 
 	--London Broil Craft Recipe
-	core.register_craft( {
+	core.register_craft({
 		output = "bbq:london_broil_raw 2",
 		type = "shapeless",
 		recipe = {"bbq:bacon", "group:food_garlic_clove", "group:food_meat"}
 	})
 
 	--Beef Jerky Craft Recipe
-	core.register_craft( {
+	core.register_craft({
 		output = "bbq:beef_jerky_raw 3",
 		type = "shapeless",
 		recipe = {"bbq:liquid_smoke", "bbq:brine", "group:food_meat"}
 	})
 
 	--Pepper Steak Craft Recipe
-	core.register_craft( {
+	core.register_craft({
 		output = "bbq:pepper_steak_raw",
 		type = "shapeless",
 		recipe = {"group:food_pepper_ground", "group:food_meat", "group:food_pepper_ground"}
@@ -163,49 +137,49 @@ if core.get_modpath("bbq") then
 	-- *** group:food_bread
 
 	--Cheese Steak Craft Recipe
-	core.register_craft( {
+	core.register_craft({
 		output = "bbq:cheese_steak 2",
 		type = "shapeless",
 		recipe = {"group:food_bread", "group:food_pepper", "bbq:beef", "group:food_cheese", "group:food_onion"}
 	})
 
 	--Bacon Cheeseburger Craft Recipe
-	core.register_craft( {
+	core.register_craft({
 		output = "bbq:bacon_cheeseburger 3",
 		type = "shapeless",
 		recipe = {"group:food_bread", "bbq:bacon", "bbq:hamburger_patty", "group:food_cheese"}
 	})
 
 	--Bacon Cheeseburger Craft Recipe
-	core.register_craft( {
+	core.register_craft({
 		output = "bbq:bacon_cheeseburger 3",
 		type = "shapeless",
 		recipe = {"group:food_bread", "bbq:bacon", "group:food_meat", "group:food_cheese"}
 	})
 
 	--Hamburger Craft Recipe
-	core.register_craft( {
+	core.register_craft({
         output = "bbq:hamburger 2",
 		type = "shapeless",
 		recipe = {"group:food_bread", "bbq:hamburger_patty"}
 	})
 
 	--Hamburger Craft Recipe
-	core.register_craft( {
+	core.register_craft({
 		output = "bbq:hamburger 2",
 		type = "shapeless",
 		recipe = {"group:food_bread", "group:food_meat"}
 	})
 
 	--Hotdog Craft Recipe
-	core.register_craft( {
+	core.register_craft({
 		output = "bbq:hotdog 2",
 		type = "shapeless",
 		recipe = {"bbq:hotdog_cooked", "group:food_bread"}
 	})
 
 	--Pulled Pork Craft Recipe
-	core.register_craft( {
+	core.register_craft({
 		output = "bbq:pulled_pork 2",
 		type = "shapeless",
 		recipe = {"mobs:pork_cooked", "group:food_bread", "bbq:bbq_sauce"}
@@ -213,28 +187,28 @@ if core.get_modpath("bbq") then
 
 
 	--Stuffed Chop Craft Recipe
-	core.register_craft( {
+	core.register_craft({
 		output = "bbq:stuffed_chop_raw 3",
 		type = "shapeless",
 		recipe = {"group:food_onion", "group:food_bread", "flowers:mushroom_brown", "mobs:pork_raw", "default:apple"}
 	})
 
 	--Stuffed Mushroom Craft Recipe
-	core.register_craft( {
+	core.register_craft({
 		output = "bbq:stuffed_mushroom_raw 2",
 		type = "shapeless",
 		recipe = {"group:food_tomato", "group:food_bread", "flowers:mushroom_brown"}
 	})
 
 	--Stuffed Pepper Craft Recipe
-	core.register_craft( {
+	core.register_craft({
 		output = "bbq:stuffed_pepper_raw 3",
 		type = "shapeless",
 		recipe = {"group:food_cheese", "group:food_bread", "group:food_pepper"}
 	})
 
     -- bbq:bacon_raw
-	core.register_craft( {
+	core.register_craft({
 		output = "bbq:bacon_raw 3",
 		recipe = {
 			{"bbq:basting_brush", "group:dye,color_red", "group:dye,color_white"},
@@ -243,7 +217,7 @@ if core.get_modpath("bbq") then
         replacements = {{"bbq:basting_brush", "bbq:basting_brush"}}
     })
 
-	core.register_craft( {
+	core.register_craft({
 		output = "bbq:bbq_chicken_raw",
 		recipe = {
 			{"bbq:basting_brush", "bbq:hot_sauce", "cucina_vegana:tofu"},
@@ -253,7 +227,7 @@ if core.get_modpath("bbq") then
         replacements = {{"bbq:basting_brush", "bbq:basting_brush"}}
     })
 
-	core.register_craft( {
+	core.register_craft({
 		output = "bbq:beef_raw",
 		recipe = {
 			{"bbq:basting_brush", "group:dye,color_red", "bbq:sea_salt"},
@@ -262,14 +236,14 @@ if core.get_modpath("bbq") then
         replacements = {{"bbq:basting_brush", "bbq:basting_brush"}}
     })
 
-	core.register_craft( {
+	core.register_craft({
 		output = "bbq:ham_raw",
 		recipe = {
 			{"cucina_vegana:tofu", "bbq:liquid_smoke", "cucina_vegana:tofu"},
 		}
     })
 
-	core.register_craft( {
+	core.register_craft({
 		output = "bbq:hot_wings_raw 2",
 		recipe = {
 			{"cucina_vegana:tofu", "", "cucina_vegana:tofu"},
@@ -278,7 +252,7 @@ if core.get_modpath("bbq") then
         }
     })
 
-	core.register_craft( {
+	core.register_craft({
 		output = "bbq:hotdog_raw 3",
 		recipe = {
 			{"bbq:basting_brush", "group:food_salt", ""},
@@ -288,9 +262,9 @@ if core.get_modpath("bbq") then
         replacements = {{"bbq:basting_brush", "bbq:basting_brush"}}
     })
 
-    core.register_craft( {
-    output = "bbq:leg_lamb_raw",
-    recipe = {
+    core.register_craft({
+        output = "bbq:leg_lamb_raw",
+        recipe = {
 			{"bbq:basting_brush", "cucina_vegana:imitation_butter", "cucina_vegana:soy_milk"},
 			{"cucina_vegana:imitation_meat", "", ""},
 			{"group:food_salt", "", ""},
@@ -298,19 +272,20 @@ if core.get_modpath("bbq") then
         replacements = {{"bbq:basting_brush", "bbq:basting_brush"}}
     })
 
-    core.register_craft( {
+    core.register_craft({
         output = "bbq:rack_lamb_raw",
         recipe = {
 			{"bbq:basting_brush", "", "default:stick"},
 			{"cucina_vegana:imitation_meat", "", "default:stick"},
 			{"bbq:spatula", "", "default:stick"},
         },
-        replacements = {{"bbq:basting_brush", "bbq:basting_brush"},
-                        {"bbq:spatula", "bbq:spatula"},
-                        }
+        replacements = {
+            {"bbq:basting_brush", "bbq:basting_brush"},
+            {"bbq:spatula", "bbq:spatula"},
+        }
     })
 
-    core.register_craft( {
+    core.register_craft({
         output = "bbq:lamb_kebab_raw",
         recipe = {
 			{"bbq:leg_lamb_raw", "default:stick", ""},
@@ -319,21 +294,15 @@ if core.get_modpath("bbq") then
     })
 
     core.log("info", "[MOD] " .. modname .. ": bbq supported.")
+end
 
-end -- if core.get_modpath("bbq"
-
---[[
-        **************************************************
-        ***             Support for pizza              ***
-        **************************************************
-]]--
-
+-- Support for pizza
 if core.get_modpath("pizza") then
     core.register_craft({
         type = "shapeless",
         output = "pizza:pizza_dough",
         recipe = {"group:food_flour", "group:food_cheese", "group:food_tomato"},
-        })
+    })
 
     cucina_vegana.add_group("pizza:pizza_dough", {pizza_dough = 1})
 
@@ -341,25 +310,18 @@ if core.get_modpath("pizza") then
         type = "shapeless",
         output = "pizza:pizza_dough",
         recipe = {"cucina_vegana:pizza_dough"}
-                            })
+    })
 
     core.register_craft({
         type = "shapeless",
         output = "cucina_vegana:pizza_dough",
         recipe = {"pizza:pizza_dough"}
-                            })
-
+    })
 end
 
---[[
-        **************************************************
-        ***             Support for homedecor          ***
-        **************************************************
-]]--
-
+-- Support for homedecor
 if core.get_modpath("homedecor") then
-
-    core.register_craft( {
+    core.register_craft({
         output = "homedecor:cobweb_corner 5",
         recipe = {
 			{ "cucina_vegana:flax_roasted", "", "cucina_vegana:flax_roasted" },
@@ -420,15 +382,9 @@ if core.get_modpath("homedecor") then
             { "", "basic_materials:plastic_strip", "basic_materials:plastic_strip" },
         },
     })
-
 end
 
---[[
-        **************************************************
-        ***      Support for building_blocks           ***
-        **************************************************
-]]--
-
+-- Support for building_blocks
 if core.get_modpath("building_blocks") then
     core.register_craft({
         output = 'building_blocks:terrycloth_towel 2',
@@ -436,7 +392,6 @@ if core.get_modpath("building_blocks") then
             {"cucina_vegana:flax_roasted", "cucina_vegana:flax_roasted", "cucina_vegana:flax_roasted"},
         }
     })
-
 end
 
 --[[
@@ -462,15 +417,9 @@ if core.get_modpath("ropes") then
 			{'cucina_vegana:flax_roasted'},
 		}
 	})
-
 end
 
---[[
-        **************************************************
-        ***             Support for cottages           ***
-        **************************************************
-]]--
-
+-- Support for cottages
 if core.get_modpath("cottages") then
     core.register_craft({
         output = "cottages:rope",
@@ -480,15 +429,9 @@ if core.get_modpath("cottages") then
             {"","","cucina_vegana:flax_roasted"},
             }
     })
-
 end
 
---[[
-        **************************************************
-        ***             Support for moreblocks         ***
-        **************************************************
-]]--
-
+-- Support for moreblocks
 if core.get_modpath("moreblocks") then
     core.register_craft({
         output = "moreblocks:rope 3",
@@ -498,24 +441,17 @@ if core.get_modpath("moreblocks") then
             {"cucina_vegana:flax_roasted"},
         }
     })
-
 end
 
---[[
-        **************************************************
-        ***             Support for petz               ***
-        **************************************************
-]]--
-
+-- Support for petz
 if core.get_modpath("petz") then
-
     core.register_craft({
-	output = "petz:lasso",
-	recipe = {
-		{"cucina_vegana:flax_roasted", "", "cucina_vegana:flax_roasted"},
-		{"", "default:diamond", ""},
-		{"cucina_vegana:flax_roasted", "", "cucina_vegana:flax_roasted"},
-            }
+	    output = "petz:lasso",
+	    recipe = {
+		    {"cucina_vegana:flax_roasted", "", "cucina_vegana:flax_roasted"},
+		    {"", "default:diamond", ""},
+		    {"cucina_vegana:flax_roasted", "", "cucina_vegana:flax_roasted"},
+        }
     })
 
     core.register_craft({
@@ -576,36 +512,29 @@ if core.get_modpath("petz") then
         type = "shaped",
         output = "petz:dreamcatcher",
         recipe = {
-                    {"", "group:wood", ""},
-                    {"cucina_vegana:flax_roasted", "cucina_vegana:flax_roasted", "cucina_vegana:flax_roasted"},
-                    {"petz:ducky_feather", "petz:ducky_feather", "petz:ducky_feather"},
-                }
+            {"", "group:wood", ""},
+            {"cucina_vegana:flax_roasted", "cucina_vegana:flax_roasted", "cucina_vegana:flax_roasted"},
+            {"petz:ducky_feather", "petz:ducky_feather", "petz:ducky_feather"},
+        }
     })
 
     core.register_craft({
         type = "shaped",
         output = "petz:ducky_feather",
         recipe = {
-                    {"cucina_vegana:flax_roasted", "default:stick", "cucina_vegana:flax_roasted"},
-                    {"cucina_vegana:flax_roasted", "default:stick", "cucina_vegana:flax_roasted"},
-                    {"", "default:stick", ""},
-                }
+            {"cucina_vegana:flax_roasted", "default:stick", "cucina_vegana:flax_roasted"},
+            {"cucina_vegana:flax_roasted", "default:stick", "cucina_vegana:flax_roasted"},
+            {"", "default:stick", ""},
+        }
     })
 
     cucina_vegana.add_group("petz:cheese", {food_cheese = 1, eatable = 1})
     cucina_vegana.add_group("petz:milk", {food_milk = 1, eatable = 1})
     cucina_vegana.add_group("petz:honey_bottle", {food_sugar = 1, food_honey = 1})
+end
 
-end -- if core.get_modpath("petz"
-
---[[
-        **************************************************
-        ***         Support for aqua_farming           ***
-        **************************************************
-]]--
-
+-- Support for aqua_farming
 if core.get_modpath("aqua_farming") then
-
     core.register_craft({
         output = "cucina_vegana:vegan_sushi",
         recipe = {	{"cucina_vegana:imitation_fish", "cucina_vegana:bowl_rice", ""},
@@ -619,23 +548,20 @@ if core.get_modpath("aqua_farming") then
     core.register_craft({
         output = "cucina_vegana:imitation_fish",
         recipe = {
-                    {"aqua_farming:sea_grass_item","cucina_vegana:tofu", "group:dye,color_blue"},
-                    {"cucina_vegana:tofu","aqua_farming:sea_grass_item", "cucina_vegana:tofu"},
-                    {"","cucina_vegana:tofu", ""},
-
-                },
+            {"aqua_farming:sea_grass_item","cucina_vegana:tofu", "group:dye,color_blue"},
+            {"cucina_vegana:tofu","aqua_farming:sea_grass_item", "cucina_vegana:tofu"},
+            {"","cucina_vegana:tofu", ""},
+        },
     })
 
     core.register_craft({
         output = "cucina_vegana:sea_salad",
         recipe = {
-                    {"aqua_farming:sea_cucumber_item","cucina_vegana:parsley", "cucina_vegana:lettuce"},
-                    {"cucina_vegana:chives","aqua_farming:sea_anemone_item", "cucina_vegana:asparagus"},
-                    {"","cucina_vegana:bowl", ""},
-
-                },
+            {"aqua_farming:sea_cucumber_item","cucina_vegana:parsley", "cucina_vegana:lettuce"},
+            {"cucina_vegana:chives","aqua_farming:sea_anemone_item", "cucina_vegana:asparagus"},
+            {"","cucina_vegana:bowl", ""},
+        },
     })
-
 end
 
 cucina_vegana.add_group("default:blueberries", {food_blueberry = 1, food_blueberries = 1})

--- a/register_mods.lua
+++ b/register_mods.lua
@@ -1,135 +1,120 @@
+local cv_items = {
+    --                Name                          Saturation      Replace with                Poison  Heal    Sound
+    -- crops
+    {'cucina_vegana:asparagus',                     3,              nil,                        nil,    nil,    nil},
+    {'cucina_vegana:chives',                        1,              nil,                        nil,    nil,    nil},
+    {'cucina_vegana:kohlrabi',                      3,              nil,                        nil,    nil,    nil},
+    {'cucina_vegana:lettuce',                       2,              nil,                        nil,    nil,    nil},
+    {'cucina_vegana:parsley',                       1,              nil,                        nil,    nil,    nil},
+    {'cucina_vegana:peanut',                        3,              nil,                        nil,    nil,    nil},
+    {'cucina_vegana:rosemary',                      1,              nil,                        nil,    nil,    nil},
+    {'cucina_vegana:sunflower_seeds',               1,              nil,                        nil,    nil,    nil},
+    {'cucina_vegana:banana',                        4,              nil,                        nil,    nil,    nil},
+    {'cucina_vegana:tomato',                        4,              nil,                        nil,    nil,    nil},
+    {'cucina_vegana:potato',                        5,              nil,                        nil,    nil,    nil},
+    {'cucina_vegana:carrot',                        3,              nil,                        nil,    nil,    nil},
+    {'cucina_vegana:chili',                         1,              nil,                        nil,    nil,    nil},
+    {'cucina_vegana:onion',                         3,              nil,                        nil,    nil,    nil},
+    {'cucina_vegana:corn',                          2,              nil,                        nil,    nil,    nil},
+    {'cucina_vegana:cucumber',                      3,              nil,                        nil,    nil,    nil},
+    {'cucina_vegana:strawberry',                    2,              nil,                        nil,    nil,    nil},
+    {'cucina_vegana:vine_grape',                    3,              nil,                        nil,    nil,    nil},
 
-    local cv_items = {
-      --                Name                          Saturation      Replace with                Poison  Heal    Sound
-      -- crops
-      {'cucina_vegana:asparagus',                     3,              nil,                        nil,    nil,    nil},
-      {'cucina_vegana:chives',                        1,              nil,                        nil,    nil,    nil},
-      {'cucina_vegana:kohlrabi',                      3,              nil,                        nil,    nil,    nil},
-      {'cucina_vegana:lettuce',                       2,              nil,                        nil,    nil,    nil},
-      {'cucina_vegana:parsley',                       1,              nil,                        nil,    nil,    nil},
-      {'cucina_vegana:peanut',                        3,              nil,                        nil,    nil,    nil},
-      {'cucina_vegana:rosemary',                      1,              nil,                        nil,    nil,    nil},
-      {'cucina_vegana:sunflower_seeds',               1,              nil,                        nil,    nil,    nil},
-      {'cucina_vegana:banana',                        4,              nil,                        nil,    nil,    nil},
-      {'cucina_vegana:tomato',                        4,              nil,                        nil,    nil,    nil},
-      {'cucina_vegana:potato',                        5,              nil,                        nil,    nil,    nil},
-      {'cucina_vegana:carrot',                        3,              nil,                        nil,    nil,    nil},
-      {'cucina_vegana:chili',                         1,              nil,                        nil,    nil,    nil},
-      {'cucina_vegana:onion',                         3,              nil,                        nil,    nil,    nil},
-      {'cucina_vegana:corn',                          2,              nil,                        nil,    nil,    nil},
-      {'cucina_vegana:cucumber',                      3,              nil,                        nil,    nil,    nil},
-      {'cucina_vegana:strawberry',                    2,              nil,                        nil,    nil,    nil},
-      {'cucina_vegana:vine_grape',                    3,              nil,                        nil,    nil,    nil},
+    -- side dishes
+    {'cucina_vegana:ciabatta_bread',                4,              nil,                        nil,    nil,    nil},
+    {'cucina_vegana:blueberry_jam',                 8,              'vessels:glass_bottle',     nil,    nil,    nil},
+    {'cucina_vegana:blueberry_puree',               4,              nil,                        nil,    nil,    nil},
+    {'cucina_vegana:dandelion_honey',               3,              'vessels:glass_bottle',     nil,    nil,    nil},
+    {'cucina_vegana:edamame_cooked',                3,              'cucina_vegana:plate',      nil,    0.1,    nil},
+    {'cucina_vegana:flax_seed_oil',                 2,              'vessels:glass_bottle',     nil,    nil,    nil},
+    {'cucina_vegana:kohlrabi_roasted',              4,              nil,                        nil,    nil,    nil},
+    {'cucina_vegana:lettuce_oil',                   2,              'vessels:glass_bottle',     nil,    nil,    nil},
+    {'cucina_vegana:peanut_oil',                    4,              'vessels:glass_bottle',     nil,    nil,    nil},
+    {'cucina_vegana:peanut_butter',                 7,              'vessels:glass_bottle',     nil,    nil,    nil},
+    {'cucina_vegana:salad_bowl',                    4,              'cucina_vegana:bowl',       nil,    nil,    nil},
+    {'cucina_vegana:sauce_hollandaise',             3,              'vessels:glass_bottle',     nil,    nil,    nil},
+    {'cucina_vegana:sunflower_seeds_oil',           3,              'vessels:glass_bottle',     nil,    nil,    nil},
+    {'cucina_vegana:soy_milk',                      1,              'vessels:drinking_glass',   nil,    0.5,    nil},
+    {'cucina_vegana:vegan_strawberry_milk',         3,              'vessels:drinking_glass',   nil,    nil,    nil},
+    {'cucina_vegana:coffee_cup',                    2,              'vessels:drinking_glass',   nil,    nil,    nil},
+    {'cucina_vegana:coffee_cup_hot',                2,              'vessels:drinking_glass',   nil,    nil,    nil},
+    {'cucina_vegana:cucumber_in_glass',             5,              'vessels:glass_bottle',     nil,    0.5,    nil},
 
-      --               Name                          Saturation      Replace with                Poison  Heal    Sound
-      -- side dishes
-      {'cucina_vegana:ciabatta_bread',                4,              nil,                        nil,    nil,    nil},
-      {'cucina_vegana:blueberry_jam',                 8,              'vessels:glass_bottle',     nil,    nil,    nil},
-      {'cucina_vegana:blueberry_puree',               4,              nil,                        nil,    nil,    nil},
-      {'cucina_vegana:dandelion_honey',               3,              'vessels:glass_bottle',     nil,    nil,    nil},
-      {'cucina_vegana:edamame_cooked',                3,              'cucina_vegana:plate',      nil,    0.1,    nil},
-      {'cucina_vegana:flax_seed_oil',                 2,              'vessels:glass_bottle',     nil,    nil,    nil},
-      {'cucina_vegana:kohlrabi_roasted',              4,              nil,                        nil,    nil,    nil},
-      {'cucina_vegana:lettuce_oil',                   2,              'vessels:glass_bottle',     nil,    nil,    nil},
-      {'cucina_vegana:peanut_oil',                    4,              'vessels:glass_bottle',     nil,    nil,    nil},
-      {'cucina_vegana:peanut_butter',                 7,              'vessels:glass_bottle',     nil,    nil,    nil},
-      {'cucina_vegana:salad_bowl',                    4,              'cucina_vegana:bowl',       nil,    nil,    nil},
-      {'cucina_vegana:sauce_hollandaise',             3,              'vessels:glass_bottle',     nil,    nil,    nil},
-      {'cucina_vegana:sunflower_seeds_oil',           3,              'vessels:glass_bottle',     nil,    nil,    nil},
-      {'cucina_vegana:soy_milk',                      1,              'vessels:drinking_glass',   nil,    0.5,    nil},
-      {'cucina_vegana:vegan_strawberry_milk',         3,              'vessels:drinking_glass',   nil,    nil,    nil},
-      {'cucina_vegana:coffee_cup',                    2,              'vessels:drinking_glass',   nil,    nil,    nil},
-      {'cucina_vegana:coffee_cup_hot',                2,              'vessels:drinking_glass',   nil,    nil,    nil},
-      {'cucina_vegana:cucumber_in_glass',             5,              'vessels:glass_bottle',     nil,    0.5,    nil},
+    -- eatable raws
+    {'cucina_vegana:imitation_butter',              2,              nil,                        nil,    0.5,    nil},
+    {'cucina_vegana:imitation_cheese',              3,              nil,                        nil,    0.5,    nil},
+    {'cucina_vegana:imitation_fish',                3,              nil,                        nil,    0.5,    nil},
+    {'cucina_vegana:imitation_meat',                3,              nil,                        nil,    0.5,    nil},
+    {'cucina_vegana:sunflower_seeds_dough',         2,              nil,                        nil,    0.5,    nil},
+    {'cucina_vegana:tofu',                          2,              nil,                        nil,    0.5,    nil},
 
-      --               Name                          Saturation      Replace with                Poison  Heal    Sound
-      -- eatable raws
-      {'cucina_vegana:imitation_butter',              2,              nil,                        nil,    0.5,    nil},
-      {'cucina_vegana:imitation_cheese',              3,              nil,                        nil,    0.5,    nil},
-      {'cucina_vegana:imitation_fish',                3,              nil,                        nil,    0.5,    nil},
-      {'cucina_vegana:imitation_meat',                3,              nil,                        nil,    0.5,    nil},
-      {'cucina_vegana:sunflower_seeds_dough',         2,              nil,                        nil,    0.5,    nil},
-      {'cucina_vegana:tofu',                          2,              nil,                        nil,    0.5,    nil},
+    -- dinners
+    {'cucina_vegana:asparagus_hollandaise_cooked',  5,              'cucina_vegana:plate',      nil,    1.5,    nil},
+    {'cucina_vegana:asparagus_rice_cooked',         6,              'cucina_vegana:plate',      nil,    1.5,    nil},
+    {'cucina_vegana:asparagus_soup_cooked',         5,              'cucina_vegana:plate',      nil,    0.5,    nil},
+    {'cucina_vegana:bread_garlic_cooked',           4,              nil,                        nil,    0.5,    nil},
+    {'cucina_vegana:bowl_rice_cooked',              4,              'cucina_vegana:bowl',       nil,    nil,    nil},
+    {'cucina_vegana:fish_parsley_rosemary_cooked',  6,              'cucina_vegana:plate',      nil,    1.5,    nil},
+    {'cucina_vegana:fryer',                         8,              nil,                        nil,    3.0,    nil},
+    {'cucina_vegana:kohlrabi_soup_cooked',          5,              'cucina_vegana:plate',      nil,    1.5,    nil},
+    {'cucina_vegana:pizza_vegana',                  6,              nil,                        nil,    2.0,    nil},
+    {'cucina_vegana:pizza_funghi',                  6,              nil,                        nil,    2.0,    nil},
+    {'cucina_vegana:salad_hollandaise',             4,              'cucina_vegana:bowl',       nil,    nil,    nil},
+    {'cucina_vegana:sea_salad',                     5,              'cucina_vegana:bowl',       nil,    1.5,    nil},
+    {'cucina_vegana:soy_soup_cooked',               5,              'cucina_vegana:plate',      nil,    0.5,    nil},
+    {'cucina_vegana:sunflower_seeds_bread',         4,              nil,                        nil,    0.5,    nil},
+    {'cucina_vegana:sunflower_seeds_roasted',       3,              nil,                        nil,    nil,    nil},
+    {'cucina_vegana:tofu_chives_rosemary_cooked',   6,              'cucina_vegana:plate',      nil,    2.0,    nil},
+    {'cucina_vegana:tofu_cooked',                   3,              nil,                        nil,    nil,    nil},
+    {'cucina_vegana:vegan_sushi',                   4,              nil,                        nil,    1.5,    nil},
+}
 
-      --               Name                          Saturation      Replace with                Poison  Heal    Sound
-                -- dinners
-      {'cucina_vegana:asparagus_hollandaise_cooked',  5,              'cucina_vegana:plate',      nil,    1.5,    nil},
-      {'cucina_vegana:asparagus_rice_cooked',         6,              'cucina_vegana:plate',      nil,    1.5,    nil},
-      {'cucina_vegana:asparagus_soup_cooked',         5,              'cucina_vegana:plate',      nil,    0.5,    nil},
-      {'cucina_vegana:bread_garlic_cooked',           4,              nil,                        nil,    0.5,    nil},
-      {'cucina_vegana:bowl_rice_cooked',              4,              'cucina_vegana:bowl',       nil,    nil,    nil},
-      {'cucina_vegana:fish_parsley_rosemary_cooked',  6,              'cucina_vegana:plate',      nil,    1.5,    nil},
-      {'cucina_vegana:fryer',                         8,              nil,                        nil,    3.0,    nil},
-      {'cucina_vegana:kohlrabi_soup_cooked',          5,              'cucina_vegana:plate',      nil,    1.5,    nil},
-      {'cucina_vegana:pizza_vegana',                  6,              nil,                        nil,    2.0,    nil},
-      {'cucina_vegana:pizza_funghi',                  6,              nil,                        nil,    2.0,    nil},
-      {'cucina_vegana:salad_hollandaise',             4,              'cucina_vegana:bowl',       nil,    nil,    nil},
-      {'cucina_vegana:sea_salad',                     5,              'cucina_vegana:bowl',       nil,    1.5,    nil},
-      {'cucina_vegana:soy_soup_cooked',               5,              'cucina_vegana:plate',      nil,    0.5,    nil},
-      {'cucina_vegana:sunflower_seeds_bread',         4,              nil,                        nil,    0.5,    nil},
-      {'cucina_vegana:sunflower_seeds_roasted',       3,              nil,                        nil,    nil,    nil},
-      {'cucina_vegana:tofu_chives_rosemary_cooked',   6,              'cucina_vegana:plate',      nil,    2.0,    nil},
-      {'cucina_vegana:tofu_cooked',                   3,              nil,                        nil,    nil,    nil},
-      {'cucina_vegana:vegan_sushi',                   4,              nil,                        nil,    1.5,    nil},
+local grinder_recipes = {
+    -- Other
+    {"cucina_vegana:sunflower_seeds 3",             "cucina_vegana:sunflower_seeds_flour"},
+    {"cucina_vegana:rice 3",                        "cucina_vegana:rice_flour"},
+    {"cucina_vegana:coffee_beans_roasted 2",        "cucina_vegana:coffee_powder"},
+}
 
-
-    } -- civ_items
-
-    local grinder_recipes = {
-        -- Other
-        {"cucina_vegana:sunflower_seeds 3",             "cucina_vegana:sunflower_seeds_flour"},
-        {"cucina_vegana:rice 3",                        "cucina_vegana:rice_flour"},
-        {"cucina_vegana:coffee_beans_roasted 2",        "cucina_vegana:coffee_powder"},
-    }
---   *******************************************
---   *****           Technic-Support       *****
---   *******************************************
-
-if(core.get_modpath("technic")) then
-
+-- Technic-Support
+if core.get_modpath("technic") then
 
 	-- Support Compressor
 	local compressor_recipes = {
-                    {"cucina_vegana:kohlrabi 6", "cucina_vegana:molasses"},
-                    {"cucina_vegana:sunflower_seeds 6", "cucina_vegana:sunflower_seeds_oil"},
-                    {"cucina_vegana:soy 8", "cucina_vegana:tofu"},
-                    {"default:blueberries 6", "cucina_vegana:blueberry_puree"},
-                    {"farming:blueberries 6", "cucina_vegana:blueberry_puree"},
-                    {"bushes:blueberry 6", "cucina_vegana:blueberry_puree"},
-                }
+        {"cucina_vegana:kohlrabi 6", "cucina_vegana:molasses"},
+        {"cucina_vegana:sunflower_seeds 6", "cucina_vegana:sunflower_seeds_oil"},
+        {"cucina_vegana:soy 8", "cucina_vegana:tofu"},
+        {"default:blueberries 6", "cucina_vegana:blueberry_puree"},
+        {"farming:blueberries 6", "cucina_vegana:blueberry_puree"},
+        {"bushes:blueberry 6", "cucina_vegana:blueberry_puree"},
+    }
 
-    if(cucina_vegana.farming_default) then
-            table.insert(compressor_recipes,{"cucina_vegana:seed_lettuce 6", "cucina_vegana:lettuce_oil"})
-            table.insert(compressor_recipes,{"cucina_vegana:seed_flax 6", "cucina_vegana:flax_seed_oil"})
-            table.insert(compressor_recipes,{"cucina_vegana:seed_peanut 6", "cucina_vegana:peanut_oil"})
-            table.insert(compressor_recipes,{"cucina_vegana:seed_corn 6", "cucina_vegana:corn_oil"})
-
+    if cucina_vegana.farming_default then
+        table.insert(compressor_recipes, {"cucina_vegana:seed_lettuce 6", "cucina_vegana:lettuce_oil"})
+        table.insert(compressor_recipes, {"cucina_vegana:seed_flax 6", "cucina_vegana:flax_seed_oil"})
+        table.insert(compressor_recipes, {"cucina_vegana:seed_peanut 6", "cucina_vegana:peanut_oil"})
+        table.insert(compressor_recipes, {"cucina_vegana:seed_corn 6", "cucina_vegana:corn_oil"})
     else
-            table.insert(compressor_recipes,{"cucina_vegana:lettuce_seed 6", "cucina_vegana:lettuce_oil"})
-            table.insert(compressor_recipes,{"cucina_vegana:flax_seed 6", "cucina_vegana:flax_seed_oil"})
-            table.insert(compressor_recipes,{"cucina_vegana:peanut_seed 6", "cucina_vegana:peanut_oil"})
-            table.insert(compressor_recipes,{"cucina_vegana:corn_seed 6", "cucina_vegana:corn_oil"})
-
-    end -- if(cucina_vegana.farming_default
+        table.insert(compressor_recipes, {"cucina_vegana:lettuce_seed 6", "cucina_vegana:lettuce_oil"})
+        table.insert(compressor_recipes, {"cucina_vegana:flax_seed 6", "cucina_vegana:flax_seed_oil"})
+        table.insert(compressor_recipes, {"cucina_vegana:peanut_seed 6", "cucina_vegana:peanut_oil"})
+        table.insert(compressor_recipes, {"cucina_vegana:corn_seed 6", "cucina_vegana:corn_oil"})
+    end
 
 	for _, data in pairs(compressor_recipes) do
-
 		technic.register_compressor_recipe({input = {data[1]}, output = data[2]})
-
 	end
 
 	-- Support Centrifuge
 	local centrifuge_recipes = {
-					{ "flowers:sunflower",             "cucina_vegana:sunflower_seeds 4",       "dye:yellow"      },
-                    { "cucina_vegana:sunflower",       "cucina_vegana:sunflower_seeds 4",       "dye:yellow"      },
-                    { "cucina_vegana:kohlrabi 4",      "cucina_vegana:molasses",                "default:leaves"  },
-                    { "cucina_vegana:corn",            "cucina_vegana:seed_corn 10",            "default:leaves"  },
-				}
+		{ "flowers:sunflower",             "cucina_vegana:sunflower_seeds 4",       "dye:yellow"      },
+        { "cucina_vegana:sunflower",       "cucina_vegana:sunflower_seeds 4",       "dye:yellow"      },
+        { "cucina_vegana:kohlrabi 4",      "cucina_vegana:molasses",                "default:leaves"  },
+        { "cucina_vegana:corn",            "cucina_vegana:seed_corn 10",            "default:leaves"  },
+	}
 
 	for _, data in pairs(centrifuge_recipes) do
-
 		technic.register_separating_recipe({ input = { data[1] }, output = { data[2], data[3], data[4] } })
-
 	end
 
 	-- Support Extractor
@@ -143,7 +128,7 @@ if(core.get_modpath("technic")) then
 	}
 
     -- Special Recipes with Seeds
-    if(cucina_vegana.farming_default) then
+    if cucina_vegana.farming_default then
         table.insert(extractor_recipes,{"cucina_vegana:seed_lettuce 6", "cucina_vegana:lettuce_oil"})
         table.insert(extractor_recipes,{"cucina_vegana:seed_flax 6", "cucina_vegana:flax_seed_oil"})
         table.insert(extractor_recipes,{"cucina_vegana:seed_peanut 6", "cucina_vegana:peanut_oil"})
@@ -153,9 +138,7 @@ if(core.get_modpath("technic")) then
         table.insert(extractor_recipes,{"cucina_vegana:flax_seed 6", "cucina_vegana:flax_seed_oil"})
         table.insert(extractor_recipes,{"cucina_vegana:peanut_seed 6", "cucina_vegana:peanut_oil"})
         table.insert(extractor_recipes,{"cucina_vegana:corn_seed 6", "cucina_vegana:corn_oil"})
-
-    end -- if(cucina_vegana.farming_default
-
+    end
 
 	for _, data in ipairs(extractor_recipes) do
 		technic.register_extractor_recipe({input = {data[1]}, output = data[2]})
@@ -163,9 +146,9 @@ if(core.get_modpath("technic")) then
 
     -- Support Alloy_Furnace
     local alloy_recipes = {
-    {"farming:flour 3",                      "cucina_vegana:sunflower_seeds","cucina_vegana:sunflower_seeds_bread"},
-    {"cucina_vegana:sunflower_seeds_flour 3","cucina_vegana:sunflower_seeds","cucina_vegana:sunflower_seeds_bread"},
-    {"cucina_vegana:rice_flour 3",           "cucina_vegana:sunflower_seeds","cucina_vegana:sunflower_seeds_bread"},
+        {"farming:flour 3", "cucina_vegana:sunflower_seeds", "cucina_vegana:sunflower_seeds_bread"},
+        {"cucina_vegana:sunflower_seeds_flour 3", "cucina_vegana:sunflower_seeds", "cucina_vegana:sunflower_seeds_bread"},
+        {"cucina_vegana:rice_flour 3", "cucina_vegana:sunflower_seeds", "cucina_vegana:sunflower_seeds_bread"},
     }
 
     for _, data in pairs(alloy_recipes) do
@@ -175,104 +158,69 @@ if(core.get_modpath("technic")) then
     -- Support Grinder
     for _, data in pairs(grinder_recipes) do
         technic.register_grinder_recipe({input = {data[1]}, output = data[2]})
-
     end
+end
 
-end -- if(core.get_modpath("technic"
-
---   *******************************************
---   *****           Hunger-Support        *****
---   *******************************************
-
-if(core.get_modpath("hunger")) then
+-- Hunger-Support
+if core.get_modpath("hunger") then
     for key, item in pairs(cv_items) do
         hunger.register_food(item)
+    end
+end
 
-    end -- for key, data
-
-end -- hunger
-
---   **********************************************
---   *****           Hunger_ng-Support        *****
---   **********************************************
-
-if(core.get_modpath("hunger_ng")) then
+-- Hunger_ng-Support
+if core.get_modpath("hunger_ng") then
     local add = hunger_ng.add_hunger_data
 
     for key, item in pairs(cv_items) do
         add(item[1], {satiates = item[2], returns = item[3], heals = math.floor((item[5] or 0)), timeout = 0})
+    end
+end
 
-    end -- for key, data
+-- Wine-Support
+if core.get_modpath("wine") then
+    wine:add_item({
+        {"cucina_vegana:molasses", "wine:glass_rum"},
+        {"cucina_vegana:dandelion_honey", "wine:glass_mead"},
+        {"cucina_vegana:rice", "wine:glass_sake"},
+        {"cucina_vegana:vine_grape", "wine:glass_wine"}
+    })
+end
 
-end -- hunger_ng
-
---   *******************************************
---   *****           Wine-Support          *****
---   *******************************************
-
-if(core.get_modpath("wine")) then
-    wine:add_item({ {"cucina_vegana:molasses", "wine:glass_rum"},
-                    {"cucina_vegana:dandelion_honey", "wine:glass_mead"},
-                    {"cucina_vegana:rice", "wine:glass_sake"},
-                    {"cucina_vegana:vine_grape", "wine:glass_wine"}
-                  })
-
-end -- wine
-
---   *******************************************
---   *****           Diet-Support          *****
---   *******************************************
-
-if(core.get_modpath("diet")) then
-
+-- Diet-Support
+if core.get_modpath("diet") then
     local function overwrite(name, hunger_change, replace_with_item, poisen, heal)
         local tab = core.registered_items[name]
         if not tab then
             return
         end
         tab.on_use = diet.item_eat(hunger_change, replace_with_item, poisen, heal)
-    end -- local function overwrite
+    end
 
     for key,item in pairs(cv_items) do
         overwrite(item[1], item[2], item[3], item[4], item[5])
+    end
+end
 
-    end -- for key,item
-
-end -- if(core.get_modpath("diet
-
---   *******************************************
---   *****           Petz-Support          *****
---   *******************************************
-
-if(core.get_modpath("petz")) then
+-- Petz-Support
+if core.get_modpath("petz") then
     cucina_vegana.add_group("petz:bucket_milk", {food_milk = 1})
     cucina_vegana.add_group("petz:chicken_egg", {food = 2, food_egg = 1})
     cucina_vegana.add_group("petz:ducky_egg",{food = 2, food_egg = 1})
-
 end
 
---   *******************************************
---   *****      Lemontree-Support          *****
---   *******************************************
-
-if(core.get_modpath("lemontree")) then
+-- Lemontree-Support
+if core.get_modpath("lemontree") then
     cucina_vegana.add_group("lemontree:lemon", {food_lemon = 1, food_fruit = 1})
-
 end
 
---   *******************************************
---   *****      Clementinetree-Support          *****
---   *******************************************
-
-if(core.get_modpath("clementinetree")) then
+-- Clementinetree-Support
+if core.get_modpath("clementinetree") then
     cucina_vegana.add_group("clementinetree:clementine", {food_orange = 1, food_fruit = 1})
-
 end
 
---   *******************************************
---   *****      Techage-Support          *****
---   *******************************************
-if(core.get_modpath("techage") and techage.register_plant) then
+-- Techage-Support
+if core.get_modpath("techage") and techage.register_plant then
 	for name,ndef in pairs(core.registered_nodes) do
 		if type(name) == "string" then
 			local mod = string.split(name, ":")[1]
@@ -286,7 +234,5 @@ if(core.get_modpath("techage") and techage.register_plant) then
 
     for _, crop in pairs(grinder_recipes) do
         techage.add_grinder_recipe({input=crop[1], output=crop[2]})
-
     end
-
 end

--- a/register_signs_bot.lua
+++ b/register_signs_bot.lua
@@ -7,14 +7,11 @@ function cucina_vegana.register_signs_bot(pname, start, steps)
 	local fp = signs_bot.register_farming_plant
 	local mname = cucina_vegana.modname
 
-    if(cucina_vegana.farming_default) then
+    if cucina_vegana.farming_default then
         fp("cucina_vegana:seed_" .. pname, "cucina_vegana:" .. pname .. "_"
-        .. start, "cucina_vegana:" .. pname .. "_" .. steps)
-
+                .. start, "cucina_vegana:" .. pname .. "_" .. steps)
     else
         fp("cucina_vegana:" .. pname .. "_seed", "cucina_vegana:" .. pname .. "_"
-        .. start, "cucina_vegana:" .. pname .. "_" .. steps)
-
+                .. start, "cucina_vegana:" .. pname .. "_" .. steps)
     end
-
 end

--- a/rice.lua
+++ b/rice.lua
@@ -28,42 +28,45 @@ core.register_node("cucina_vegana:wild_" .. pname, {
 	paramtype = "light",
 	walkable = false,
 	drop = {
-			items = {
-					{items = {"cucina_vegana:seed_" .. pname .. " 3"}},
-					{items = {"cucina_vegana:" .. pname}},
-				}
-			},
+		items = {
+			{items = {"cucina_vegana:seed_" .. pname .. " 3"}},
+			{items = {"cucina_vegana:" .. pname}},
+		}
+	},
 	drawtype = "plantlike",
 	paramtype2 = "facedir",
 	tiles = {"cucina_vegana_" .. pname .. "_" .. step .. ".png"},
 	sunlight_propagates = true,
-	groups = {snappy = 3, dig_immediate=1, flammable=2, plant=1, attached_node = 1,
-                growing = 1, not_in_creative_inventory = 1},
+	groups = {
+		snappy = 3, dig_immediate = 1, flammable = 2, plant = 1,
+		attached_node = 1, growing = 1, not_in_creative_inventory = 1
+	},
 	sounds = default.node_sound_leaves_defaults(),
 	selection_box = {
-			type = "fixed",
-			fixed = {
-				{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
-			},
+		type = "fixed",
+		fixed = {
+			{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
+		},
 	},
 })
 
-if(cucina_vegana.plant_settings.bonemeal) then
-    table.insert(cucina_vegana.plant_settings.bonemeal_list,
-                 {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:seed_" .. pname})
-
-end -- if(cucina_vegana.plant_settings.bonemeal
+if cucina_vegana.plant_settings.bonemeal then
+	local table = {
+		"cucina_vegana:" .. pname .. "_",
+		step,
+		"cucina_vegana:seed_" .. pname
+	}
+    table.insert(cucina_vegana.plant_settings.bonemeal_list, table)
+end
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then
     cucina_vegana.register_farming_ng(pname, step)
-
-end -- if(cucina_vegana.farming_ng
+end
 
 -- Register @ Signs_bot
-if(cucina_vegana.signs_bot) then
+if cucina_vegana.signs_bot then
     cucina_vegana.register_signs_bot(pname, 1, step)
-
 end
 
 core.register_decoration({

--- a/rosemary.lua
+++ b/rosemary.lua
@@ -28,42 +28,45 @@ core.register_node("cucina_vegana:wild_" .. pname, {
 	paramtype = "light",
 	walkable = false,
 	drop = {
-			items = {
-					{items = {"cucina_vegana:seed_" .. pname .. " 3"}},
-					{items = {"cucina_vegana:" .. pname}},
-				}
-			},
+		items = {
+			{items = {"cucina_vegana:seed_" .. pname .. " 3"}},
+			{items = {"cucina_vegana:" .. pname}},
+		}
+	},
 	drawtype = "plantlike",
 	paramtype2 = "facedir",
 	tiles = {"cucina_vegana_" .. pname .. "_6.png"},
 	sunlight_propagates = true,
-	groups = {snappy = 3, dig_immediate=1, flammable=2, plant=1, attached_node = 1,
-                growing = 1, not_in_creative_inventory = 1},
+	groups = {
+		snappy = 3, dig_immediate = 1, flammable = 2, plant = 1,
+		attached_node = 1, growing = 1, not_in_creative_inventory = 1
+	},
 	sounds = default.node_sound_leaves_defaults(),
 	selection_box = {
-			type = "fixed",
-			fixed = {
-				{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
-			},
+		type = "fixed",
+		fixed = {
+			{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
+		},
 	},
 })
 
-if(cucina_vegana.plant_settings.bonemeal) then
-    table.insert(cucina_vegana.plant_settings.bonemeal_list,
-                 {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:seed_" .. pname})
-
-end -- if(cucina_vegana.plant_settings.bonemeal
+if cucina_vegana.plant_settings.bonemeal then
+	local table = {
+		"cucina_vegana:" .. pname .. "_",
+		step,
+		"cucina_vegana:seed_" .. pname
+	}
+    table.insert(cucina_vegana.plant_settings.bonemeal_list, table)
+end
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then
     cucina_vegana.register_farming_ng(pname, step)
-
-end -- if(cucina_vegana.farming_ng
+end
 
 -- Register @ Signs_bot
-if(cucina_vegana.signs_bot) then
+if cucina_vegana.signs_bot then
     cucina_vegana.register_signs_bot(pname, 1, step)
-
 end
 
 core.register_decoration({

--- a/soy.lua
+++ b/soy.lua
@@ -27,26 +27,27 @@ core.register_node("cucina_vegana:wild_".. pname, {
 	paramtype = "light",
 	walkable = false,
 	drop = {
-			items = {
-					{items = {"cucina_vegana:seed_".. pname .. " 3"}},
-					{items = {"cucina_vegana:".. pname}},
-				}
-			},
+		items = {
+			{items = {"cucina_vegana:seed_".. pname .. " 3"}},
+			{items = {"cucina_vegana:".. pname}},
+		}
+	},
 	drawtype = "plantlike",
 	paramtype2 = "facedir",
 	tiles = {"cucina_vegana_".. pname .. "_".. step .. ".png"},
 	sunlight_propagates = true,
-	groups = {snappy = 3, dig_immediate=1, flammable=2, plant=1, attached_node = 1,
-                growing = 1, not_in_creative_inventory = 1},
+	groups = {
+		snappy = 3, dig_immediate = 1, flammable = 2, plant = 1,
+		attached_node = 1, growing = 1, not_in_creative_inventory = 1
+	},
 	sounds = default.node_sound_leaves_defaults(),
 	selection_box = {
-			type = "fixed",
-			fixed = {
-				{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
-			},
+		type = "fixed",
+		fixed = {
+			{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
+		},
 	},
 })
-
 
 cucina_vegana.add_group("cucina_vegana:seed_"..pname, {seed_soy = 1})
 
@@ -54,20 +55,22 @@ core.register_alias("soy:wild_".. pname, "cucina_vegana:wild_".. pname)
 core.register_alias("soy:".. pname, "cucina_vegana:".. pname)
 core.register_alias("soy:seed_".. pname, "cucina_vegana:seed_".. pname)
 
-if(cucina_vegana.plant_settings.bonemeal) then
-    table.insert(cucina_vegana.plant_settings.bonemeal_list,
-                 {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:seed_" .. pname})
-
-end -- if(cucina_vegana.plant_settings.bonemeal
+if cucina_vegana.plant_settings.bonemeal then
+	local table = {
+		"cucina_vegana:" .. pname .. "_",
+		step,
+		"cucina_vegana:seed_" .. pname
+	}
+    table.insert(cucina_vegana.plant_settings.bonemeal_list, table)
+end
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then
     cucina_vegana.register_farming_ng(pname, step)
-
-end -- if(cucina_vegana.farming_ng
+end
 
 -- Register @ Signs_bot
-if(cucina_vegana.signs_bot) then
+if cucina_vegana.signs_bot then
     cucina_vegana.register_signs_bot(pname, 1, step)
 end
 

--- a/strawberry.lua
+++ b/strawberry.lua
@@ -28,48 +28,57 @@ core.register_node("cucina_vegana:wild_" .. pname, {
 	paramtype = "light",
 	walkable = false,
 	drop = {
-			items = {
-					{items = {"cucina_vegana:seed_" .. pname .. " 3"}},
-					{items = {"cucina_vegana:" .. pname .. ""}},
-				}
-			},
+		items = {
+			{items = {"cucina_vegana:seed_" .. pname .. " 3"}},
+			{items = {"cucina_vegana:" .. pname .. ""}},
+		}
+	},
 	drawtype = "plantlike",
 	paramtype2 = "facedir",
 	tiles = {"cucina_vegana_" .. pname .. "_" .. step .. ".png"},
 	sunlight_propagates = true,
-	groups = {snappy = 3, dig_immediate=1, flammable=2, plant=1, attached_node = 1,
-                growing = 1, not_in_creative_inventory = 1},
+	groups = {
+		snappy = 3, dig_immediate = 1, flammable = 2, plant = 1,
+		attached_node = 1, growing = 1, not_in_creative_inventory = 1
+	},
 	sounds = default.node_sound_leaves_defaults(),
 	selection_box = {
-			type = "fixed",
-			fixed = {
-				{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
-			},
+		type = "fixed",
+		fixed = {
+			{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
+		},
 	},
 })
 
-if(cucina_vegana.plant_settings.bonemeal) then
-    table.insert(cucina_vegana.plant_settings.bonemeal_list,
-								{"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:seed_" .. pname})
-
-end -- if(cucina_vegana.plant_settings.bonemeal
+if cucina_vegana.plant_settings.bonemeal then
+	local table = {
+		"cucina_vegana:" .. pname .. "_",
+		step,
+		"cucina_vegana:seed_" .. pname
+	}
+    table.insert(cucina_vegana.plant_settings.bonemeal_list, table)
+end
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then
     cucina_vegana.register_farming_ng(pname, step)
-
-end -- if(cucina_vegana.farming_ng
+end
 
 -- Register @ Signs_bot
-if(cucina_vegana.signs_bot) then
+if cucina_vegana.signs_bot then
     cucina_vegana.register_signs_bot(pname, 1, step)
-
 end
 
 core.register_decoration({
 	deco_type = "simple",
-	place_on = {"default:dirt_with_grass", "default:dirt_with_rainforest_litter", "default:dirt_with_coniferous_litter", "default:dirt_with_dry_grass"},
-	spawn_by = {"default:tree", "default:aspen_tree", "default:jungletree", "default:fernt_1", "default:fern_2", "default:fern_3"},
+	place_on = {
+		"default:dirt_with_grass", "default:dirt_with_rainforest_litter",
+		"default:dirt_with_coniferous_litter", "default:dirt_with_dry_grass"
+	},
+	spawn_by = {
+		"default:tree", "default:aspen_tree", "default:jungletree",
+		"default:fernt_1", "default:fern_2", "default:fern_3"
+	},
 	sidelen = 16,
 	noise_params = {
 		offset = 0,

--- a/sunflower.lua
+++ b/sunflower.lua
@@ -1,14 +1,11 @@
 local modpath = core.get_modpath(core.get_current_modname())
 
-if(core.registered_nodes["flowers:sunflower"]  ~= nil) then
+if core.registered_nodes["flowers:sunflower"] then
 	print("[MOD] " .. core.get_current_modname() .. " Sunflowers available.")
 	print("[MOD] " .. core.get_current_modname() .. " using \"flowers:sunflower\".")
-
 else
-
 	print("[MOD] " .. core.get_current_modname() .. " no Sunflowers available.")
 	print("[MOD] " .. core.get_current_modname() .. " use own Sunflowers.")
-
 
 	core.register_decoration({
 		deco_type = "simple",
@@ -25,11 +22,8 @@ else
 		y_min = 0,
 		y_max = 150,
 		decoration = "cucina_vegana:wild_sunflower",
-		})
+	})
 
 	core.register_alias("flowers:sunflower", "cucina_vegana:sunflower")
-
-
-		dofile(modpath .. "/sunflower_def.lua")
-
+	dofile(modpath .. "/sunflower_def.lua")
 end

--- a/sunflower_def.lua
+++ b/sunflower_def.lua
@@ -12,13 +12,9 @@ local pname = "sunflower"
 local step = 5
 local modname = core.get_current_modname()
 
-if(core.registered_nodes["flowers:sunflower"]  ~= nil) then
-	print("[MOD] " .. modname .. " Sunflowers available.")
-	print("[MOD] " .. modname .. " using \"flowers:sunflower\".")
+if core.registered_nodes["flowers:sunflower"] then
     core.log("info", "[MOD] " .. modname .. ": Sunflowers available. Using \"flowers:sunflower\".")
-
 else
-
 	farming.register_plant("cucina_vegana:" .. pname, {
 		description = dname .. " " .. S("Seed"),
         harvest_description = dname,
@@ -35,45 +31,47 @@ else
 		paramtype = "light",
 		walkable = false,
 		drop = {
-				items = {
-						{items = {"cucina_vegana:seed_" .. pname .. " 2"}},
-						{items = {"cucina_vegana:" .. pname .. ""}},
-					}
-				},
+			items = {
+				{items = {"cucina_vegana:seed_" .. pname .. " 2"}},
+				{items = {"cucina_vegana:" .. pname .. ""}},
+			}
+		},
 		drawtype = "plantlike",
 		paramtype2 = "facedir",
 		tiles = {"cucina_vegana_" .. pname .. "_" .. step .. ".png"},
 		sunlight_propagates = true,
-		groups = {snappy = 3, dig_immediate=1, flammable=2, plant=1, attached_node = 1,
-                growing = 1, not_in_creative_inventory = 1},
+		groups = {
+			snappy = 3, dig_immediate = 1, flammable = 2, plant = 1,
+			attached_node = 1, growing = 1, not_in_creative_inventory = 1
+		},
 		sounds = default.node_sound_leaves_defaults(),
 		selection_box = {
-				type = "fixed",
-				fixed = {
-					{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
-				},
+			type = "fixed",
+			fixed = {
+				{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
+			},
 		},
 	})
 
 	core.override_item("cucina_vegana:" .. pname .. "_4", {visual_scale = 1.3})
 	core.override_item("cucina_vegana:" .. pname .. "_5", {visual_scale = 1.5})
-
 end
 
-if(cucina_vegana.plant_settings.bonemeal) then
-    table.insert(cucina_vegana.plant_settings.bonemeal_list,
-                 {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:seed_" .. pname})
-
-end -- if(cucina_vegana.plant_settings.bonemeal
+if cucina_vegana.plant_settings.bonemeal then
+	local table = {
+		"cucina_vegana:" .. pname .. "_",
+		step,
+		"cucina_vegana:seed_" .. pname
+	}
+    table.insert(cucina_vegana.plant_settings.bonemeal_list, table)
+end
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then
     cucina_vegana.register_farming_ng(pname, step)
-
-end -- if(cucina_vegana.farming_ng
+end
 
 -- Register @ Signs_bot
-if(cucina_vegana.signs_bot) then
+if cucina_vegana.signs_bot then
     cucina_vegana.register_signs_bot(pname, 1, step)
-
 end

--- a/tomato.lua
+++ b/tomato.lua
@@ -28,44 +28,47 @@ core.register_node("cucina_vegana:wild_" .. pname, {
 	paramtype = "light",
 	walkable = false,
 	drop = {
-			items = {
-					{items = {"cucina_vegana:seed_" .. pname .. " 4"}},
-					{items = {"cucina_vegana:" .. pname .. " 3"}},
-				}
-			},
+		items = {
+			{items = {"cucina_vegana:seed_" .. pname .. " 4"}},
+			{items = {"cucina_vegana:" .. pname .. " 3"}},
+		}
+	},
 	drawtype = "plantlike",
 	paramtype2 = "facedir",
 	sunlight_propagates = true,
 	tiles = {"cucina_vegana_" .. pname .. "_" .. step .. ".png"},
-	groups = {snappy = 3, dig_immediate=1, flammable=2, plant=1, attached_node = 1,
-                growing = 1, not_in_creative_inventory = 1},
+	groups = {
+		snappy = 3, dig_immediate = 1, flammable = 2, plant = 1,
+		attached_node = 1, growing = 1, not_in_creative_inventory = 1
+	},
 	sounds = default.node_sound_leaves_defaults(),
 	selection_box = {
-			type = "fixed",
-			fixed = {
-				{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
-			},
+		type = "fixed",
+		fixed = {
+			{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
+		},
 	},
 })
 
 cucina_vegana.add_group("cucina_vegana:seed_" .. pname, {seed_tomato = 1})
 
-if(cucina_vegana.plant_settings.bonemeal) then
-    table.insert(cucina_vegana.plant_settings.bonemeal_list,
-                 {"cucina_vegana:" .. pname .. "_", step, "cucina_vegana:seed_" .. pname})
-
-end -- if(cucina_vegana.plant_settings.bonemeal
+if cucina_vegana.plant_settings.bonemeal then
+	local table = {
+		"cucina_vegana:" .. pname .. "_",
+		step,
+		"cucina_vegana:seed_" .. pname
+	}
+    table.insert(cucina_vegana.plant_settings.bonemeal_list, table)
+end
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then
     cucina_vegana.register_farming_ng(pname, step)
-
-end -- if(cucina_vegana.farming_ng
+end
 
 -- Register @ Signs_bot
-if(cucina_vegana.signs_bot) then
-        cucina_vegana.register_signs_bot(pname, 1, step)
-
+if cucina_vegana.signs_bot then
+    cucina_vegana.register_signs_bot(pname, 1, step)
 end
 
 core.register_decoration({

--- a/tools.lua
+++ b/tools.lua
@@ -1,79 +1,66 @@
 --[[
 	**********************************************
-	***   Helpfuntcions for cucina_vegana      ***
+	***   Help funtcions for cucina_vegana     ***
 	**********************************************
 ]]--
 
 function cucina_vegana.table_clone(c_table)
-  local t2 = {}
-  for k,v in pairs(c_table) do
-    t2[k] = v
+    local t2 = {}
+    for k,v in pairs(c_table) do
+        t2[k] = v
+    end
 
-  end
-
-  return t2
-
-end -- function cucina_vegana.table_clone
+    return t2
+end
 
 function cucina_vegana.add_group(node, entry)
+    if type(node) ~= "string" then
+        return
+    end
 
     local newgroup
 
-    if(type(node) ~= "string") then return end
-
     -- Check the Item and get the group
-    if(core.registered_items[node] ~= nil) then
+    if core.registered_items[node] ~= nil then
         newgroup = cucina_vegana.table_clone(core.registered_items[node].groups)
 
-    elseif(core.registered_tools[node] ~= nil) then
+    elseif core.registered_tools[node] ~= nil then
         newgroup = cucina_vegana.table_clone(core.registered_tools[node].groups)
 
     else -- Node not found.
         return
-
-    end -- if(core.registered_nodes
+    end
 
     -- add the new groups to the item
     for key,value in pairs(entry) do
         newgroup[key] = value
-
     end
 
-    core.override_item(node, {
-                                  groups = newgroup
-                                 })
-
-end -- function cucina_vegana.add_group()
+    core.override_item(node, {groups = newgroup})
+end
 
 function cucina_vegana.register_farming_ng(pname, step)
     local germ = tonumber(cucina_vegana.plant_settings.germ_launch)
     local modname = cucina_vegana.modname
 
     if cucina_vegana.farming_default then
-        if(germ > 0) then
+        if germ > 0 then
             farmingNG.register_seed("cucina_vegana:seed_" .. pname, "cucina_vegana:" .. pname .. "_" .. germ)
             farmingNG.register_harvest("cucina_vegana:" .. pname .. "_" .. step)
-
         else
             farmingNG.register_seed("cucina_vegana:seed_" .. pname, "cucina_vegana:seed_" .. pname)
             farmingNG.register_harvest("cucina_vegana:" .. pname .. "_" .. step)
-
-        end -- if(germ > 0
+        end
 
     else
-        if(germ > 0) then
+        if germ > 0 then
             farmingNG.register_seed("cucina_vegana:" .. pname .. "_seed", "cucina_vegana:" .. pname .. "_" .. germ)
             farmingNG.register_harvest("cucina_vegana:" .. pname .. "_" .. step)
-
         else
             farmingNG.register_seed("cucina_vegana:" .. pname .. "_seed", "cucina_vegana:" .. pname .. "_seed")
             farmingNG.register_harvest("cucina_vegana:" .. pname .. "_" .. step)
+        end
+    end
 
-        end -- if(germ > 0
-
-    end -- if cucina_vegana.farming_default
-
-    print("info", "[MOD] " .. modname .. ": cucina_vegana:seed_" .. pname .. " at farming_nextgen registered.")
     core.log("info", "[MOD] " .. modname .. ": cucina_vegana:seed_" .. pname .. " at farming_nextgen registered.")
-
-end -- cucina_vegana.register_farming_ng(
+end

--- a/vine_def.lua
+++ b/vine_def.lua
@@ -24,23 +24,25 @@ core.register_node("cucina_vegana:wild_" .. pname, {
 	walkable = true,
 	climbable = true,
 	drop = {
-			items = {
-					{items = {"cucina_vegana:" .. pname .. "_grape 2"}},
-					{items = {"cucina_vegana:" .. pname .. "_sapling 1"}},
-				}
-			},
+		items = {
+			{items = {"cucina_vegana:" .. pname .. "_grape 2"}},
+			{items = {"cucina_vegana:" .. pname .. "_sapling 1"}},
+		}
+	},
 	drawtype = "plantlike",
 	paramtype2 = "facedir",
 	sunlight_propagates = true,
 	tiles = {"cucina_vegana_" .. pname .. "_bottom_1.png"},
-	groups = {snappy = 3, dig_immediate=1, flammable=2, plant=1, attached_node = 1,
-                growing = 1, not_in_creative_inventory = 1, tree},
+	groups = {
+		snappy = 3, dig_immediate = 1, flammable = 2, plant = 1,
+		attached_node = 1, growing = 1, not_in_creative_inventory = 1, tree
+	},
 	sounds = default.node_sound_leaves_defaults(),
 	selection_box = {
-			type = "fixed",
-			fixed = {
-				{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
-			},
+		type = "fixed",
+		fixed = {
+			{-0.5, -0.5, -0.5, 0.5, -0.35, 0.5}, -- side f
+		},
 	},
 })
 
@@ -73,8 +75,8 @@ core.register_node("cucina_vegana:" .. pname .. "_leaves", {
 		}
 	},
 	after_place_node = function(...)
-							return default.after_place_leaves(...)
-						end,
+		return default.after_place_leaves(...)
+	end,
 })
 
 core.register_craftitem("cucina_vegana:" .. pname .. "_grape", {
@@ -82,7 +84,6 @@ core.register_craftitem("cucina_vegana:" .. pname .. "_grape", {
 	inventory_image = "cucina_vegana_" .. pname .. "_grape.png",
 	groups = {food = 1, food_wine = 1},
     on_use = core.item_eat(3)
-
 })
 
 core.register_node("cucina_vegana:" .. pname .. "_sapling", {
@@ -96,8 +97,10 @@ core.register_node("cucina_vegana:" .. pname .. "_sapling", {
 	tiles = {"cucina_vegana_" .. pname .. "_sapling.png"},
 	inventory_image = "cucina_vegana_" .. pname .. "_sapling.png",
 	wield_image = "cucina_vegana_" .. pname .. "_sapling.png",
-	groups = {	snappy = 3, dig_immediate=1, flammable=2, plant=1, attached_node = 1,
-                growing = 1},
+	groups = {
+		snappy = 3, dig_immediate = 1, flammable = 2, plant = 1,
+		attached_node = 1, growing = 1
+	},
 	sounds = default.node_sound_leaves_defaults(),
 	selection_box = {
 		type = "fixed",
@@ -107,7 +110,11 @@ core.register_node("cucina_vegana:" .. pname .. "_sapling", {
 	},
 })
 
-cv.lib.register_bottom_abm("cucina_vegana:" .. pname .. "_sapling", "cucina_vegana:" .. pname .. "_bottom_1", duration, maxlight)
+cv.lib.register_bottom_abm(
+	"cucina_vegana:" .. pname .. "_sapling", 
+	"cucina_vegana:" .. pname .. "_bottom_1",
+	duration, maxlight
+)
 
 for step = 1, bottom_steps do
 	core.register_node("cucina_vegana:" .. pname .. "_bottom_" .. step, {
@@ -124,23 +131,27 @@ for step = 1, bottom_steps do
 		paramtype2 = "facedir",
 		sunlight_propagates = true,
 		tiles = {"cucina_vegana_" .. pname .. "_bottom_" .. step .. ".png"},
-		groups = {	snappy = 3, flammable=2, plant=1, attached_node = 1,
-	                growing = 1, not_in_creative_inventory = 1},
+		groups = {
+			snappy = 3, flammable = 2, plant = 1, attached_node = 1,
+	        growing = 1, not_in_creative_inventory = 1
+		},
 		sounds = default.node_sound_leaves_defaults(),
 		selection_box = {
 			type = "fixed",
 			fixed = {
-						{-0.4, -0.5, -0.4, 0.4, 0.5, 0.4}, -- side f
-					},
+				{-0.4, -0.5, -0.4, 0.4, 0.5, 0.4}, -- side f
+			},
 		},
 	})
 
-	if (step < bottom_steps) then
-		cv.lib.register_bottom_abm("cucina_vegana:" .. pname .. "_bottom_" .. step, "cucina_vegana:" .. pname .. "_bottom_" .. step+1, duration, maxlight)
-
+	if step < bottom_steps then
+		cv.lib.register_bottom_abm(
+			"cucina_vegana:" .. pname .. "_bottom_" .. step,
+			"cucina_vegana:" .. pname .. "_bottom_" .. step + 1,
+			duration, maxlight
+		)
 	end
-
-end -- for step
+end
 
 core.register_abm({
     nodenames = {"cucina_vegana:" .. pname .. "_bottom_" .. bottom_steps},
@@ -148,18 +159,16 @@ core.register_abm({
     chance = percent,
     catch_up = true,
     action = function(pos, node, active_object_count, active_object_count_wider)
-                local nodepos = { x = pos.x, y = pos.y+1, z = pos.z}
-	                if(cv.lib.check_light(nodepos, maxlight)) then
-                        if(cv.lib.check_air(nodepos)) then
-                            core.set_node(nodepos, {name = "cucina_vegana:" .. pname .. "_top_1"})
-
-                        end -- if(check_air)
-
-                    end -- if(cv.check_light
-
-            end, -- function(
-
-}) -- core.register_abm({
+        local nodepos = { x = pos.x, y = pos.y+1, z = pos.z}
+	    if cv.lib.check_light(nodepos, maxlight) then
+            if cv.lib.check_air(nodepos) then
+                core.set_node(nodepos, {
+					name = "cucina_vegana:" .. pname .. "_top_1"
+				})
+            end
+        end
+    end,
+})
 
 for step = 1, top_steps do
 	core.register_node("cucina_vegana:" .. pname .. "_top_" .. step, {
@@ -168,35 +177,38 @@ for step = 1, top_steps do
 		walkable = false,
 		drop = {
 			items = {
-						{items = {"cucina_vegana:" .. pname .. "_leaves 2"}},
-						{items = {"cucina_vegana:" .. pname .. "_grape " .. step}, rarity = top_steps-step},
-						{items = {"cucina_vegana:" .. pname .. "_sapling"}, rarity = 5},
-					},
-				},
+				{items = {"cucina_vegana:" .. pname .. "_leaves 2"}},
+				{items = {"cucina_vegana:" .. pname .. "_grape " .. step}, rarity = top_steps-step},
+				{items = {"cucina_vegana:" .. pname .. "_sapling"}, rarity = 5},
+			},
+		},
 		drawtype = "plantlike",
 		paramtype2 = "facedir",
 		sunlight_propagates = true,
 		tiles = {"cucina_vegana_" .. pname .. "_top_" .. step .. ".png"},
-		groups = {	snappy = 3, dig_immediate=1, flammable=2, plant=1, attached_node = 1,
-	                growing = 1, not_in_creative_inventory = 1, tree = 1},
+		groups = {
+			snappy = 3, dig_immediate = 1, flammable = 2, plant = 1,
+			attached_node = 1, growing = 1, not_in_creative_inventory = 1, tree = 1
+		},
 		sounds = default.node_sound_leaves_defaults(),
 		selection_box = {
 			type = "fixed",
 			fixed = {
-						{-0.4, -0.5, -0.4, 0.4, 0.5, 0.4}, -- side f
-					},
+				{-0.4, -0.5, -0.4, 0.4, 0.5, 0.4}, -- side f
+			},
 		},
 	})
 
-	if (step < top_steps) then
-		cv.lib.register_top_abm("cucina_vegana:" .. pname .. "_top_" .. step, "cucina_vegana:" .. pname .. "_top_" .. step+1, duration, maxlight)
-
+	if step < top_steps then
+		cv.lib.register_top_abm(
+			"cucina_vegana:" .. pname .. "_top_" .. step,
+			"cucina_vegana:" .. pname .. "_top_" .. step + 1,
+			duration, maxlight
+		)
 	end
-
-end -- for step
+end
 
 -- Register @ farming_nextgen
 if cucina_vegana.farming_ng then
     cucina_vegana.register_farming_ng(pname, top_steps)
-
-end -- if(cucina_vegana.farming_ng
+end


### PR DESCRIPTION
This PR simplifies the indentation and code style of all individual Lua files. No functionality should have been lost, but might want to test thoroughly just in case I missed something.

- Removed unneccesary parentheses
  ```diff
  - if(cucina_vegana.plant_settings.bonemeal) then
  + if cucina_vegana.plant_settings.bonemeal then
  ```

- Removed comments after `end` keyword
  ```diff
  - end -- if(cucina_vegana.plant_settings.bonemeal
  + end
  ```

- Simplified indentation
  ```diff
 	drop = {
  -			items = {
  -					{items = {"cucina_vegana:seed_" .. pname .. " 3"}},
  -					{items = {"cucina_vegana:" .. pname .. ""}},
  -				}
  -			},
  +		items = {
  +			{items = {"cucina_vegana:seed_" .. pname .. " 3"}},
  +			{items = {"cucina_vegana:" .. pname .. ""}},
  +		}
  +	},
  ```
- Split long function calls
  ```diff
  -	if (step < top_steps) then
  -		cv.lib.register_top_abm("cucina_vegana:" .. pname .. "_top_" .. step, "cucina_vegana:" .. pname .. "_top_" .. step+1, duration, maxlight)
  -
  +	if step < top_steps then
  +		cv.lib.register_top_abm(
  +			"cucina_vegana:" .. pname .. "_top_" .. step,
  +			"cucina_vegana:" .. pname .. "_top_" .. step + 1,
  +			duration, maxlight
  +		)
 	end
  ```

I've tried to make reviewing this easier by separating each file's changes into one commit. Because of this, you can just squash the commits for this PR into one big commit if you decide to merge it so all the commits don't clutter the Git history.